### PR TITLE
Refactor content.py

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -19,7 +19,7 @@ from dooku.conf import Conf
 from dooku.decorator import cached_property
 from dooku.ext import ExtensionManager
 
-from .content import Document
+from .content import create_document
 from .utils import iterfiles
 
 
@@ -42,9 +42,8 @@ class Holocron(object):
     :param conf: (dict) a user configuration, that overrides a default one
     """
 
-    #: The class that is used for document objects. See
-    #: :class:`~holocron.content.Document` for more information.
-    document_class = Document
+    #: The factory function that is used to create a new document instance.
+    document_factory = create_document
 
     #: Default configuration parameters.
     default_conf = {
@@ -109,7 +108,7 @@ class Holocron(object):
         #: A `file extension` -> `converter` map
         #:
         #: Holds a dicionary of all registered converters, that is used to
-        #: getting converter for the :attr:`document_class`.
+        #: getting converter for the :class:`holocron.content.Document`.
         self._converters = {}
 
         #: Holds a dictionary of all registered generators. The dict is used
@@ -212,7 +211,10 @@ class Holocron(object):
         for index, document_path in enumerate(documents_paths):
             try:
                 percent = int((index + 1) * 100.0 / len(documents_paths))
-                document = self.document_class(document_path, self)
+                # TODO (@ikalnitsky):
+                #   Rethink document factory through the class. Should be
+                #   more flexible and nifty.
+                document = Holocron.document_factory(document_path, self)
                 print('[{percent:>3d}%] Building {doc}'.format(
                     percent=percent, doc=document.short_source))
 

--- a/holocron/ext/generators/blog.py
+++ b/holocron/ext/generators/blog.py
@@ -48,23 +48,19 @@ class Blog(abc.Generator):
 
         '    {% for doc in documents %}',
         '    <entry>',
-        '      <title>{{ doc.meta["title"] }}</title>',
+        '      <title>{{ doc.title }}</title>',
         '      <link href="{{ doc.abs_url }}" rel="alternate" />',
         '      <id>{{ doc.abs_url }}</id>',
 
-        '      <published>{{',
-        '        doc.get_created_datetime(localtime=True).isoformat()',
-        '      }}</published>',
-        '      <updated>{{',
-        '        doc.get_modified_datetime(localtime=True).isoformat()',
-        '      }}</updated>',
+        '      <published>{{ doc.created_local.isoformat() }}</published>',
+        '      <updated>{{ doc.updated_local.isoformat() }}</updated>',
 
         '      <author>',
-        '        <name>{{ doc.meta["author"] }}</name>',
+        '        <name>{{ doc.author }}</name>',
         '      </author>',
 
         '      <content type="html">',
-        '        {{ doc.html | e }}',
+        '        {{ doc.content | e }}',
         '      </content>',
         '    </entry>',
         '    {% endfor %}',
@@ -106,7 +102,7 @@ class Blog(abc.Generator):
         """
         posts = (doc for doc in documents if isinstance(doc, Post))
         posts = sorted(
-            posts, key=lambda d: d.get_created_datetime(), reverse=True
+            posts, key=lambda d: d.created, reverse=True
         )
 
         return posts
@@ -131,7 +127,7 @@ class Blog(abc.Generator):
         # create a dictionnary of tags to corresponding posts
         tags = defaultdict(list)
         for post in posts:
-            for tag in post.meta['tags']:
+            for tag in getattr(post, 'tags', []):
                 tags[tag].append(post)
 
         for tag in tags:

--- a/holocron/ext/generators/sitemap.py
+++ b/holocron/ext/generators/sitemap.py
@@ -40,13 +40,10 @@ class Sitemap(abc.Generator):
         '  {%- for doc in documents %}',
         '    <url>',
         '      <loc>{{ doc.abs_url }}</loc>',
-        '      <lastmod>{{',
-        '        doc.get_modified_datetime(localtime=True).isoformat()',
-        '      }}</lastmod>',
+        '      <lastmod>{{ doc.updated_local.isoformat() }}</lastmod>',
         '    </url>',
         '  {% endfor -%}',
-        '  </urlset>',
-    ]))
+        '  </urlset>', ]))
 
     def generate(self, documents):
         # it make sense to keep only convertible documents in the sitemap
@@ -55,6 +52,5 @@ class Sitemap(abc.Generator):
 
         # write sitemap to the file
         save_as = os.path.join(self.app.conf['paths.output'], self.save_as)
-
         with open(save_as, 'w', encoding='utf-8') as f:
             f.write(self.template.render(documents=documents))

--- a/holocron/themes/default/templates/document-list.html
+++ b/holocron/themes/default/templates/document-list.html
@@ -14,11 +14,6 @@
 
 
 {% block content %}
-{#- We need to add "created" attribute (which is a datetime) to all
-    posts, since we use it in "groupby" filter next in the code. -#}
-{% for post in posts %}
-  {% do setattr(post, 'created', post.get_created_datetime()) %}
-{% endfor %}
 
 {#- Prints all posts grouped by year. -#}
 <div class="index">
@@ -30,7 +25,7 @@
     <time datetime="{{ post.created.isoformat() }}">
       {{ post.created.strftime('%b %d, %Y') }}
     </time>
-    <a href="{{ post.url }}">{{ post.meta["title"] }}</a>
+    <a href="{{ post.url }}">{{ post.title }}</a>
   </div> <!-- /.index-entry -->
   {% endfor %}
 {% endfor %}

--- a/tests/ext/generators/test_sitemap.py
+++ b/tests/ext/generators/test_sitemap.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2014 by the Holocron Team, see AUTHORS for details.
     :license: 3-clause BSD, see LICENSE for details.
 """
+
 from datetime import datetime
 from unittest import mock
 from xml.dom import minidom
@@ -40,17 +41,9 @@ class TestSitemapGenerator(HolocronTestCase):
         self.post_date = datetime(2013, 4, 1)
 
         self.post = mock.Mock(
-            spec=Post,
-            abs_url=self.post_url,
-            get_modified_datetime=mock.Mock(return_value=self.post_date),
-        )
-
+            spec=Post, abs_url=self.post_url, updated_local=self.post_date)
         self.page = mock.Mock(
-            spec=Page,
-            abs_url=self.page_url,
-            get_modified_datetime=mock.Mock(return_value=self.page_date),
-        )
-
+            spec=Page, abs_url=self.page_url, updated_local=self.page_date)
         self.static = mock.Mock(spec=Static)
 
     def _get_output_content(self, documents):
@@ -63,7 +56,6 @@ class TestSitemapGenerator(HolocronTestCase):
 
             # extract what was generated and what was passed to f.write()
             content, = mopen().write.call_args[0]
-
             return content
 
     def _get_sitemap_dict(self, xml):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -121,7 +121,7 @@ class TestHolocron(HolocronTestCase):
         Tests build process.
         """
         iterfiles.return_value = ['doc_a', 'doc_b', 'doc_c']
-        self.app.document_class = mock.Mock()
+        self.app.__class__.document_factory = mock.Mock()
         self.app._copy_theme = mock.Mock()
         self.app._generators = {
             mock.Mock(): mock.Mock(),
@@ -134,7 +134,7 @@ class TestHolocron(HolocronTestCase):
         iterfiles.assert_called_with(
             self.app.conf['paths']['content'], '[!_.]*', True)
 
-        self.app.document_class.assert_has_calls([
+        self.app.__class__.document_factory.assert_has_calls([
             # check that document class was used to generate class instances
             mock.call('doc_a', self.app),
             # check that document instances were built
@@ -144,7 +144,7 @@ class TestHolocron(HolocronTestCase):
             mock.call('doc_c', self.app),
             mock.call().build(),
         ])
-        self.assertEqual(self.app.document_class.call_count, 3)
+        self.assertEqual(self.app.__class__.document_factory.call_count, 3)
 
         # check that generators was used
         for _, generator in self.app._generators.items():

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,0 +1,286 @@
+# coding: utf-8
+"""
+    tests.test_content
+    ~~~~~~~~~~~~~~~~~~
+
+    Tests Holocron's content types.
+
+    :copyright: (c) 2014 by the Holocron Team, see AUTHORS for details.
+    :license: 3-clause BSD, see LICENSE for details.
+"""
+
+import os
+import datetime
+from unittest import mock
+
+from dooku.conf import Conf
+from holocron import app, content
+from holocron.ext.converters import markdown
+
+from tests import HolocronTestCase
+
+
+class DocumentTestCase(HolocronTestCase):
+    """
+    A testcase helper that prepares a document instance.
+    """
+
+    _getcwd = 'cwd'         # fake current working dir, used by abspath
+    _getctime = 662739000   # UTC: 1991/01/01 2:10pm
+    _getmtime = 1420121400  # UTC: 2015/01/01 2:10pm
+
+    _fake_conf = Conf(app.Holocron.default_conf, {
+        'siteurl': 'http://example.com',
+        'paths': {
+            'content': './content',
+            'output': './_output', }})
+
+    document_class = None       # a document constructor
+    document_filename = None    # a document filename, relative to the content
+
+    @mock.patch('holocron.content.os.path.getmtime', return_value=_getmtime)
+    @mock.patch('holocron.content.os.path.getctime', return_value=_getctime)
+    @mock.patch('holocron.content.os.getcwd', return_value=_getcwd)
+    def setUp(self, getcwd, getctime, getmtime):
+        """
+        Prepares a document instance with a fake config.
+        """
+        filename = os.path.join(
+            self._fake_conf['paths.content'], self.document_filename)
+
+        self.doc = self.document_class(filename, mock.Mock(
+            _converters={
+                '.mdown': markdown.Markdown(self._fake_conf['converters']), },
+            conf=self._fake_conf))
+
+
+class TestDocument(DocumentTestCase):
+    """
+    Tests for an abstract document base class.
+    """
+
+    class DocumentImpl(content.Document):
+        url = '/url/to/doc'
+        build = lambda: 42
+    document_class = DocumentImpl
+    document_filename = 'about/cv.mdown'
+
+    def test_source(self):
+        """
+        The source property has to be an absolute path to the document.
+        """
+        self.assertEqual(self.doc.source, 'cwd/content/about/cv.mdown')
+
+    def test_short_source(self):
+        """
+        The short_source property has to be a path to the document relative
+        to the content directory.
+        """
+        self.assertEqual(self.doc.short_source, 'about/cv.mdown')
+
+    def test_created(self):
+        """
+        The created property has to be a datetime.datetime object in UTC.
+        """
+        self.assertIsInstance(self.doc.created, datetime.datetime)
+
+        self.assertEqual(self.doc.created.year, 1991)
+        self.assertEqual(self.doc.created.month,   1)
+        self.assertEqual(self.doc.created.day,     1)
+
+        self.assertEqual(self.doc.created.hour,   14)
+        self.assertEqual(self.doc.created.minute, 10)
+        self.assertEqual(self.doc.created.second,  0)
+
+    def test_created_local(self):
+        """
+        The created property has to be a datetime.datetime object in Local.
+        """
+        self.assertIsInstance(self.doc.created_local, datetime.datetime)
+
+        self.assertEqual(self.doc.created, self.doc.created_local)
+
+    def test_updated(self):
+        """
+        The updated property has to be a datetime.datetime object in UTC.
+        """
+        self.assertIsInstance(self.doc.updated, datetime.datetime)
+
+        self.assertEqual(self.doc.updated.year, 2015)
+        self.assertEqual(self.doc.updated.month,   1)
+        self.assertEqual(self.doc.updated.day,     1)
+
+        self.assertEqual(self.doc.updated.hour,   14)
+        self.assertEqual(self.doc.updated.minute, 10)
+        self.assertEqual(self.doc.updated.second,  0)
+
+    def test_updated_local(self):
+        """
+        The updated property has to be a datetime.datetime object in Local.
+        """
+        self.assertIsInstance(self.doc.updated_local, datetime.datetime)
+
+        self.assertEqual(self.doc.updated, self.doc.updated_local)
+
+    def test_abs_url(self):
+        """
+        The abs_url property has to be an absolute url to the resource.
+        """
+        self.assertEqual(self.doc.abs_url, 'http://example.com/url/to/doc')
+
+
+class TestPage(DocumentTestCase):
+    """
+    Tests for a Page document.
+    """
+
+    _open_fn = 'holocron.content.open'
+
+    _document_raw = '\n'.join((line.strip() for line in'''\
+    ---
+    author: Luke Skywalker
+    template: mypage.html
+    myattr: value
+    ---
+
+    My Path
+    =======
+
+    the Force is my path...
+    '''.splitlines()))
+
+    _document_no_meta_raw = 'the Force is my path...'
+
+    document_class = content.Page
+    document_filename = 'about/cv.mdown'
+
+    def setUp(self):
+        """
+        Prepares a document instance with a fake config. We need to mock
+        open function to simulate reading from the file.
+        """
+        mopen = mock.mock_open(read_data=self._document_raw)
+        with mock.patch(self._open_fn, mopen, create=True):
+            super(TestPage, self).setUp()
+
+    def test_url(self):
+        """
+        The url property has to be the same as a path relative to the
+        content folder, but without file extensions and with trailing
+        slash.
+        """
+        self.assertEqual(self.doc.url, '/about/cv/')
+
+    def test_default_attributes(self):
+        """
+        The page instance has to has a set of default attributes with
+        valid values.
+        """
+        # We need to re-run parent's setUp because we want to create
+        # a page object with default page content (without user settings).
+        mopen = mock.mock_open(read_data=self._document_no_meta_raw)
+        with mock.patch(self._open_fn, mopen, create=True):
+            super(TestPage, self).setUp()
+
+        self.assertEqual(self.doc.author, self._fake_conf['author'])
+        self.assertEqual(self.doc.template, self.document_class.template)
+        self.assertEqual(self.doc.title, self.document_class.title)
+
+    def test_custom_attributes(self):
+        """
+        The page instance has to has both default and custom attributes.
+        Moreover, the default attributes should be overriden by custom
+        ones.
+        """
+        self.assertEqual(self.doc.author, 'Luke Skywalker')
+        self.assertEqual(self.doc.template, 'mypage.html')
+        self.assertEqual(self.doc.myattr, 'value')
+        self.assertEqual(self.doc.title, 'My Path')
+
+    def test_build(self):
+        """
+        The page instance has to be rendered in the right place.
+        """
+        mopen = mock.mock_open(read_data=self._document_no_meta_raw)
+        with mock.patch(self._open_fn, mopen, create=True):
+            self.doc.build()
+
+        filename, *_ = mopen.call_args[0]
+        self.assertEqual(filename, './_output/about/cv/index.html')
+
+
+class TestPost(TestPage):
+    """
+    Tests for a Post document.
+    """
+
+    document_class = content.Post
+
+
+class TestStatic(DocumentTestCase):
+    """
+    Tests for a Static document.
+    """
+
+    document_class = content.Static
+    document_filename = 'about/me.png'
+
+    def test_url(self):
+        """
+        The url property has to be the same as a path relative to the
+        content folder.
+        """
+        self.assertEqual(self.doc.url, '/about/me.png')
+
+
+class TestDocumentFactory(HolocronTestCase):
+    """
+    Tests for the create_document functions.
+    """
+
+    @mock.patch('holocron.content.Page._parse_document', return_value={})
+    @mock.patch('holocron.content.os.path.getmtime')
+    @mock.patch('holocron.content.os.path.getctime')
+    @mock.patch('holocron.content.os.getcwd', return_value='cwd')
+    def _create_document(self, filename, getcwd, getctime, getmtime, _):
+        fake_app = mock.Mock(
+            _converters={
+                '.mdown': mock.Mock(), },
+            conf=Conf(app.Holocron.default_conf, {
+                'paths': {
+                    'content': './content', }}))
+        return content.create_document(filename, fake_app)
+
+    def test_create_post(self):
+        """
+        Tests that create_document creates a Post instance in right cases.
+        """
+        document = self._create_document('content/2015/01/04/test.mdown')
+        self.assertIsInstance(document, content.Post)
+
+    def test_create_page(self):
+        """
+        Tests that create_document creates a Page instance in right cases.
+        """
+        corner_cases = (
+            'content/test/test.mdown',
+            'content/2014/test.mdown',
+            'content/2014/01/test.mdown', )
+
+        for case in corner_cases:
+            document = self._create_document(case)
+            self.assertIsInstance(document, content.Page)
+
+    def test_create_static(self):
+        """
+        Tests that create_document creates a Static instance in right cases.
+        """
+        corner_cases = (
+            'content/2015/01/04/test.png',
+            'content/2015/01/test.png',
+            'content/2015/test.png',
+            'content/test/test.png', )
+
+        for case in corner_cases:
+            document = self._create_document(case)
+            self.assertIsInstance(document, content.Static)


### PR DESCRIPTION
It's really hard to explain what exactly was changed, so let's start
from the problem point of view. The problem is that the content.py was
ugly and had a bad design. There were a lot of unobvious things.

Here's a brief list of changes:

* the document class get rid of methods in favor of attributes
* the attributes are setted by __init__
* the destination attribute aren't a part of document interface now
* meta's attributes are document's attributes now
* the document ifself are sent to templates now