### PR TITLE
Integrate coveralls service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ env:
   - TOXENV=flake8
 
 install:
-  - pip install tox
+  - pip install tox coveralls
 
 script:
   - tox
+
+after_success:
+  - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
 envlist =
-    py33, py34, flake8
-
+  py33, py34, flake8
 
 [testenv]
-deps = pytest
+deps =
+  pytest
+  pytest-cov
 commands =
-    py.test {posargs:tests}
-
+  py.test {posargs:tests --cov holocron}
 
 [testenv:flake8]
 basepython = python3
-deps = flake8
+deps =
+  flake8
 commands =
-    flake8 {posargs:holocron tests}
+  flake8 {posargs:holocron tests}


### PR DESCRIPTION
It's very convenient to always know the current test coverage and monitor
its changes over the time. The integration has been done by direct call
in .travis.yaml. See https://coveralls.io/r/ikalnitsky/holocron for
details.