### PR TITLE
Use one VM on Travis and separate coverage tox job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ os:
   - linux
   - osx
 
-env:
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=flake8
-
 install:
   - pip install tox coveralls
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 envlist =
-  py33, py34, flake8
+  py33, py34, flake8, coverage
 
 [testenv]
 deps =
   pytest
-  pytest-cov
 commands =
-  py.test {posargs:tests --cov holocron}
+  py.test {posargs:tests}
 
 [testenv:flake8]
 basepython = python3
@@ -15,3 +14,12 @@ deps =
   flake8
 commands =
   flake8 {posargs:holocron tests}
+
+[testenv:coverage]
+basepython = python3
+deps =
+  pytest-cov
+  {[testenv]deps}
+commands =
+  coverage erase
+  py.test tests --cov holocron


### PR DESCRIPTION
Since our tests are pretty small and quick it's much quicker to run them
all on one VM. Moreover, there are no reasons to check code coverage for
all python interpreters - one is enough. Let's do not perform unnecessary
job and check coverage only when needed.