### PR TITLE
Run coveralls on python3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - "3.4"
 
 branches:
   only:


### PR DESCRIPTION
The `tox -e coverage` generates coverage report for py3 code.
Unfortunately, we can't submit this report using coveralls
installed in py2 env due to the tokenize issue (tokenize.py
in py2 just couldn't parse py3 syntax).

Well, it affects us in the way that we didn't submit coverage
report for two files:

- holocron/content.py
- holocron/ext/abc.py

We either should rewrite code in py2 compatible way or install
coveralls in py3 env. In thie patch the last solution is proposed.