### PR TITLE
Add support for content/output encoding

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -89,7 +89,10 @@ class Holocron(object):
         'siteurl': 'http://obi-wan.jedi',
         'author': 'Obi-Wan Kenobi',
 
-        'encoding': 'utf-8',
+        'encoding': {
+            'content': 'utf-8',
+            'output': 'utf-8',
+        },
 
         'paths': {
             'content': '.',
@@ -225,7 +228,8 @@ class Holocron(object):
             sitename=self.conf['sitename'],
             siteurl=self.conf['siteurl'],
             author=self.conf['author'],
-            theme=self.conf['theme'])
+            theme=self.conf['theme'],
+            encoding=self.conf['encoding.output'])
         return env
 
     def run(self):

--- a/holocron/content.py
+++ b/holocron/content.py
@@ -157,7 +157,8 @@ class Page(Document):
 
         :returns: a dictionary with parsed information
         """
-        with open(self.source, encoding='utf-8') as f:
+        encoding = self._app.conf['encoding.content']
+        with open(self.source, encoding=encoding) as f:
             headers = {}
             content = f.read()
 
@@ -183,7 +184,9 @@ class Page(Document):
         mkdir(os.path.dirname(destination))
 
         template = self._app.jinja_env.get_template(self.template)
-        with open(destination, 'w', encoding='utf-8') as f:
+        encoding = self._app.conf['encoding.output']
+
+        with open(destination, 'w', encoding=encoding) as f:
             f.write(template.render(
                 document=self,
                 sitename=self._app.conf['sitename'],

--- a/holocron/ext/generators/blog.py
+++ b/holocron/ext/generators/blog.py
@@ -36,7 +36,7 @@ class Blog(abc.Generator):
     """
     #: an atom template
     feed_template = jinja2.Template('\n'.join([
-        '<?xml version="1.0" encoding="utf-8"?>',
+        '<?xml version="1.0" encoding="{{ encoding }}"?>',
         '  <feed xmlns="http://www.w3.org/2005/Atom" >',
         '    <title>{{ credentials.sitename }} Feed</title>',
         '    <updated>{{ credentials.date.isoformat() + "Z" }}</updated>',
@@ -110,8 +110,9 @@ class Blog(abc.Generator):
         """
         save_as = self.app.conf['generators.blog.index.save_as']
         save_as = os.path.join(self._output, save_as)
+        encoding = self.app.conf['encoding.output']
 
-        with open(save_as, 'w', encoding='utf-8') as f:
+        with open(save_as, 'w', encoding=encoding) as f:
             f.write(self._template.render(
                 posts=posts,
                 sitename=self.app.conf['sitename']))
@@ -136,8 +137,9 @@ class Blog(abc.Generator):
 
             save_as = self.app.conf['generators.blog.tags.save_as']
             save_as = os.path.join(path, save_as)
+            encoding = self.app.conf['encoding.output']
 
-            with open(save_as, 'w', encoding='utf-8') as f:
+            with open(save_as, 'w', encoding=encoding) as f:
                 f.write(self._template.render(
                     posts=tags[tag],
                     sitename=self.app.conf['sitename']))
@@ -159,10 +161,11 @@ class Blog(abc.Generator):
             'date': datetime.datetime.utcnow().replace(microsecond=0), }
 
         save_as = os.path.join(self._output, save_as)
-        path = os.path.dirname(save_as)
-        mkdir(path)
+        mkdir(os.path.dirname(save_as))
+        encoding = self.app.conf['encoding.output']
 
-        with open(save_as, 'w', encoding='utf-8') as f:
+        with open(save_as, 'w', encoding=encoding) as f:
             f.write(self.feed_template.render(
                 documents=posts[:posts_number],
-                credentials=credentials))
+                credentials=credentials,
+                encoding=encoding))

--- a/holocron/ext/generators/sitemap.py
+++ b/holocron/ext/generators/sitemap.py
@@ -36,7 +36,7 @@ class Sitemap(abc.Generator):
 
     #: a sitemap template
     template = jinja2.Template('\n'.join([
-        '<?xml version="1.0" encoding="utf-8"?>',
+        '<?xml version="1.0" encoding="{{ encoding }}"?>',
         '  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
         '  {%- for doc in documents %}',
         '    <url>',
@@ -53,5 +53,8 @@ class Sitemap(abc.Generator):
 
         # write sitemap to the file
         save_as = os.path.join(self.app.conf['paths.output'], self.save_as)
-        with open(save_as, 'w', encoding='utf-8') as f:
-            f.write(self.template.render(documents=documents))
+        encoding = self.app.conf['encoding.output']
+
+        with open(save_as, 'w', encoding=encoding) as f:
+            f.write(
+                self.template.render(documents=documents, encoding=encoding))

--- a/holocron/theme/templates/base.html
+++ b/holocron/theme/templates/base.html
@@ -10,7 +10,7 @@
 
 <!doctype html>
 <head>
-  <meta charset="utf-8">
+  <meta charset="{{ encoding }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link rel="stylesheet" href="/static/holocron.css">

--- a/tests/ext/generators/test_blog.py
+++ b/tests/ext/generators/test_blog.py
@@ -41,14 +41,12 @@ class BlogTestCase(HolocronTestCase):
             'siteurl': 'www.mytest.com',
             'author': 'Tester',
 
-            'paths': {
-                'output': 'path/to/output',
+            'encoding': {
+                'output': 'my-enc',
             },
 
-            'theme': {
-                'navigation': [
-                    ('feed', '/feed.xml'),
-                ],
+            'paths': {
+                'output': 'path/to/output',
             },
 
             'generators': {
@@ -161,7 +159,7 @@ class TestIndexGenerator(BlogTestCase):
     # tag that preceds a group of posts with the same year
     year_tag = '<h2>'
 
-    def test_save_index_to_filesystem(self):
+    def test_save_index_to_filesystem_and_enc(self):
         """
         Test that index function saves index.html file to a proper location.
         """
@@ -170,6 +168,16 @@ class TestIndexGenerator(BlogTestCase):
 
             self.assertEqual(
                 mopen.call_args[0][0], 'path/to/output/myindex.html')
+            self.assertEqual(
+                mopen.call_args[1]['encoding'], 'my-enc')
+
+    def test_index_encoding_meta_tag(self):
+        """
+        The feed.xml has to have an XML tag with right encoding.
+        """
+        output = self._get_content([], self.blog.index)
+
+        self.assertIn('charset="my-enc"', output)
 
     def test_index_empty(self):
         """
@@ -334,7 +342,7 @@ class TestFeedGenerator(BlogTestCase):
         return content
 
     @mock.patch('holocron.ext.generators.blog.mkdir')
-    def test_save_feed_to_filesystem(self, _):
+    def test_feed_filename_and_enc(self, _):
         """
         Feed function has to save feed xml file to a proper location and with
         proper filename. All settings are fetched from the configuration file.
@@ -344,6 +352,16 @@ class TestFeedGenerator(BlogTestCase):
 
             self.assertEqual(
                 mopen.call_args[0][0], 'path/to/output/myfeed.xml')
+            self.assertEqual(
+                mopen.call_args[1]['encoding'], 'my-enc')
+
+    def test_feed_encoding_attr(self):
+        """
+        The feed.xml has to have an XML tag with right encoding.
+        """
+        output = self._get_content([], self.blog.feed)
+
+        self.assertIn('encoding="my-enc"', output)
 
     def test_feed_template(self):
         """

--- a/tests/ext/generators/test_sitemap.py
+++ b/tests/ext/generators/test_sitemap.py
@@ -27,6 +27,9 @@ class TestSitemapGenerator(HolocronTestCase):
         Prepares a sitemap instance with a fake config.
         """
         self.sitemap = sitemap.Sitemap(mock.Mock(conf=Conf({
+            'encoding': {
+                'output': 'my-enc',
+            },
             'paths': {
                 'output': 'path/to/output',
             }
@@ -76,7 +79,7 @@ class TestSitemapGenerator(HolocronTestCase):
 
         return content
 
-    def test_sitemap_save_to_path(self):
+    def test_sitemap_save_to_path_and_enc(self):
         """
         The sitemap generator has to place "sitemap.xml" file in the output
         folder, which is specified in holocron settings.
@@ -86,6 +89,16 @@ class TestSitemapGenerator(HolocronTestCase):
 
             self.assertEqual(
                 mopen.call_args[0][0], 'path/to/output/sitemap.xml')
+            self.assertEqual(
+                mopen.call_args[1]['encoding'], 'my-enc')
+
+    def test_sitemap_encoding_attr(self):
+        """
+        The sitemap.xml has to have an XML tag with right encoding.
+        """
+        output = self._get_output_content([])
+
+        self.assertIn('encoding="my-enc"', output)
 
     def test_sitemap_wo_documents(self):
         """

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -31,6 +31,10 @@ class DocumentTestCase(HolocronTestCase):
 
     _fake_conf = Conf(app.Holocron.default_conf, {
         'siteurl': 'http://example.com',
+        'encoding': {
+            'content': 'cont-enc',
+            'output': 'out-enc',
+        },
         'paths': {
             'content': './content',
             'output': './_output',
@@ -165,6 +169,8 @@ class TestPage(DocumentTestCase):
         with mock.patch(self._open_fn, mopen, create=True):
             super(TestPage, self).setUp()
 
+        self.assertEqual(mopen.call_args[1]['encoding'], 'cont-enc')
+
     def test_url(self):
         """
         The url property has to be the same as a path relative to the
@@ -208,8 +214,10 @@ class TestPage(DocumentTestCase):
         with mock.patch(self._open_fn, mopen, create=True):
             self.doc.build()
 
-        filename, *_ = mopen.call_args[0]
-        self.assertEqual(filename, './_output/about/cv/index.html')
+        self.assertEqual(
+            mopen.call_args[0][0], './_output/about/cv/index.html')
+
+        self.assertEqual(mopen.call_args[1]['encoding'], 'out-enc')
 
 
 class TestPost(TestPage):
@@ -236,8 +244,10 @@ class TestPost(TestPage):
         with mock.patch(self._open_fn, mopen, create=True):
             self.doc.build()
 
-        filename, *_ = mopen.call_args[0]
-        self.assertEqual(filename, './_output/2014/10/8/testpost/index.html')
+        self.assertEqual(
+            mopen.call_args[0][0], './_output/2014/10/8/testpost/index.html')
+
+        self.assertEqual(mopen.call_args[1]['encoding'], 'out-enc')
 
     def test_published(self):
         """


### PR DESCRIPTION
It's very important to add support for custom encoding, since there are
some cases when UTF-8 is not enough.

The Holocron project will support two encoding settings:

* one, used for content decoding
* one, used for output encoding

Both are defaulted to UTF-8.

Resolves #67 

@PropheticBird please review