### PR TITLE
Do not create output directory

### DIFF
--- a/tests/ext/generators/test_blog.py
+++ b/tests/ext/generators/test_blog.py
@@ -95,8 +95,8 @@ class BlogTestCase(HolocronTestCase):
         self.post_late = mock.Mock(
             spec=Post, published=self.date_late, url='www.post_late.com')
 
-    @mock.patch('holocron.ext.generators.blog.mkdir')
-    def _get_content(self, documents, test_function, _):
+    @mock.patch('holocron.ext.generators.blog.mkdir', mock.Mock())
+    def _get_content(self, documents, test_function):
         """
         This helper method mocks the open function and return the content
         passed as input to write function.
@@ -341,8 +341,8 @@ class TestFeedGenerator(BlogTestCase):
 
         return content
 
-    @mock.patch('holocron.ext.generators.blog.mkdir')
-    def test_feed_filename_and_enc(self, _):
+    @mock.patch('holocron.ext.generators.blog.mkdir', mock.Mock())
+    def test_feed_filename_and_enc(self):
         """
         Feed function has to save feed xml file to a proper location and with
         proper filename. All settings are fetched from the configuration file.

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -205,8 +205,8 @@ class TestPage(DocumentTestCase):
         self.assertEqual(self.doc.myattr, 'value')
         self.assertEqual(self.doc.title, 'My Path')
 
-    @mock.patch('holocron.content.mkdir')
-    def test_build(self, mkdir):
+    @mock.patch('holocron.content.mkdir', mock.Mock())
+    def test_build(self):
         """
         The page instance has to be rendered in the right place.
         """
@@ -236,6 +236,7 @@ class TestPost(TestPage):
         """
         self.assertEqual(self.doc.url, '/2014/10/8/testpost/')
 
+    @mock.patch('holocron.content.mkdir', mock.Mock())
     def test_build(self):
         """
         The post instance has to be rendered in the right place.


### PR DESCRIPTION
We shouldn't create output directory during test run since we don't need
it and it requires filesystem write permissions.