### PR TITLE
Change published attribute type to datetime

### DIFF
--- a/holocron/content.py
+++ b/holocron/content.py
@@ -221,10 +221,10 @@ class Post(Page):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        date = self.short_source.split(os.sep)[:3]
-        date = ''.join(date)
+        published = ''.join(self.short_source.split(os.sep)[:3])
+        published = datetime.datetime.strptime(published, '%Y%m%d')
 
-        self.published = datetime.datetime.strptime(date, '%Y%m%d').date()
+        self.published = published.replace(tzinfo=Local)
 
 
 class Static(Document):


### PR DESCRIPTION
We used to kept `published` attribute as date type, but it led to the
following issues:

* `date` type doesn't contain a timezone information, therefore it's
  impossible to convert it into RFC3339 format (at least, there's no
  simple way)
* `published` attribute should have a timezone information, since a
  published date is a specific for timezone

Since now the `published` attribute has a `datetime` type with localtime
timezone.

Fixes #96