### PR TITLE
Fix pep8 errors

### DIFF
--- a/tests/ext/generators/test_feed.py
+++ b/tests/ext/generators/test_feed.py
@@ -109,11 +109,13 @@ class TestFeedGenerator(HolocronTestCase):
         root = parsed.documentElement
 
         #: use this to sort DOM Elements from DOM Text containing \n and spaces
-        is_element = lambda n: n.nodeType == n.ELEMENT_NODE
+        def is_element(n): return n.nodeType == n.ELEMENT_NODE
+
         #: use this to parse <link> which contain attributes instead of values
-        is_attribute = lambda n: len(n.attributes) != 0
+        def is_attribute(n): return len(n.attributes) != 0
+
         #: use this to distinguish feed common elements (link, title) from post
-        has_child = lambda n: len(n.childNodes) < 2
+        def has_child(n): return len(n.childNodes) < 2
 
         urls = [url for url in filter(is_element, root.childNodes)]
 

--- a/tests/ext/generators/test_sitemap.py
+++ b/tests/ext/generators/test_sitemap.py
@@ -70,7 +70,7 @@ class TestSitemapGenerator(HolocronTestCase):
 
         content = {root.nodeName: []}
 
-        is_element = lambda n: n.nodeType == n.ELEMENT_NODE
+        def is_element(n): return n.nodeType == n.ELEMENT_NODE
 
         for url in filter(is_element, root.childNodes):
             url_data = {attr.nodeName: attr.firstChild.nodeValue

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -67,7 +67,10 @@ class TestDocument(DocumentTestCase):
 
     class DocumentImpl(content.Document):
         url = '/url/to/doc'
-        build = lambda: 42
+
+        def build(self):
+            return 42
+
     document_class = DocumentImpl
     document_filename = 'about/cv.mdown'
 


### PR DESCRIPTION
Since pep8 1.6.0 (2015-02-06) the lambda assignment throws an error:

    E731 do not assign a lambda expression, use a def

This commit provides changes that are ok for latest pep8.