### PR TITLE
Pass command line arguments to commands' execute

### DIFF
--- a/holocron/ext/abc.py
+++ b/holocron/ext/abc.py
@@ -31,11 +31,12 @@ class Command(object, metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def execute(self, app):
+    def execute(self, app, arguments):
         """
         Execute is a uniform method used to execute commands.
 
         :param app: an application instance
+        :param arguments: a Namespace object with parsed command line arguments
         """
 
 

--- a/holocron/ext/commands/build.py
+++ b/holocron/ext/commands/build.py
@@ -17,5 +17,5 @@ class Build(abc.Command):
     Generates a static site for a given Holocron instance.
     """
 
-    def execute(self, app):
+    def execute(self, app, arguments):
         app.run()

--- a/holocron/ext/commands/init.py
+++ b/holocron/ext/commands/init.py
@@ -30,7 +30,7 @@ class Init(abc.Command):
     #: path to an example content
     content = os.path.join(os.path.dirname(holocron.__file__), 'example')
 
-    def execute(self, app):
+    def execute(self, app, arguments):
         if os.listdir(os.curdir) != []:
             logger.error('Init command cannot run in a non-empty directory.')
             return

--- a/holocron/main.py
+++ b/holocron/main.py
@@ -114,4 +114,4 @@ def main():
         sys.exit(1)
 
     command = command_manager[arguments.command]()
-    command.execute(holocron)
+    command.execute(holocron, arguments)


### PR DESCRIPTION
We should pass parses command line arguments to commands' executor since
the command may want to use it. For example, the Serve command has to
know about conf path because it's watching for conf and re-build entire
blog if changes were detected.

Fixed #75