### PR TITLE
Print message after 'holocron init' command

### DIFF
--- a/holocron/ext/commands/init.py
+++ b/holocron/ext/commands/init.py
@@ -11,9 +11,9 @@
 
 import os
 import logging
+import textwrap
 
 from distutils.dir_util import copy_tree
-from distutils.errors import DistutilsFileError
 
 import holocron
 from holocron.ext import abc
@@ -27,18 +27,23 @@ class Init(abc.Command):
     Creates a blog skeleton in the current working directory.
     """
 
-    #: path to an example content
-    content = os.path.join(os.path.dirname(holocron.__file__), 'example')
+    _content = os.path.join(os.path.dirname(holocron.__file__), 'example')
 
     def execute(self, app, arguments):
-        if os.listdir(os.curdir) != []:
-            logger.error('Init command cannot run in a non-empty directory.')
-            return
+        if os.listdir(os.curdir):
+            return logger.error('Could not initialize non-empty directory.')
 
-        try:
-            copied_files = copy_tree(self.content, os.curdir)
-            for file_ in copied_files:
-                logger.info('%s: created', file_)
+        copy_tree(self._content, os.curdir)
 
-        except DistutilsFileError:
-            logger.error('Holocron example content was not found.')
+        print(textwrap.dedent('''
+            The current working directory has been initialized with a blog
+            template. Here are some commands you might be interested in:
+
+               $ holocron build     # compile blog into static html
+               $ holocron serve     # preview blog in your browser
+
+            Look into the documentation https://holocron.readthedocs.org
+            for details.
+
+            May the Force be with you!
+        '''))

--- a/tests/ext/commands/__init__.py
+++ b/tests/ext/commands/__init__.py
@@ -1,0 +1,10 @@
+# coding: utf-8
+"""
+    tests.ext.commands
+    ~~~~~~~~~~~~~~~~~~
+
+    The package contains tests for standard commands.
+
+    :copyright: (c) 2015 by the Holocron Team, see AUTHORS for details.
+    :license: 3-clause BSD, see LICENSE for details.
+"""

--- a/tests/ext/commands/test_build.py
+++ b/tests/ext/commands/test_build.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+"""
+    tests.ext.commands.test_build
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests Build command.
+
+    :copyright: (c) 2015 by the Holocron Team, see AUTHORS for details.
+    :license: 3-clause BSD, see LICENSE for details.
+"""
+
+from unittest import mock
+
+from holocron.app import Holocron
+from holocron.ext.commands import build
+
+from tests import HolocronTestCase
+
+
+class TestBuildCommand(HolocronTestCase):
+
+    def test_run_holocron(self):
+        fake_app = mock.Mock(spec=Holocron)
+
+        command = build.Build()
+        command.execute(app=fake_app, arguments=None)
+
+        fake_app.run.assert_called_with()

--- a/tests/ext/commands/test_init.py
+++ b/tests/ext/commands/test_init.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+"""
+    tests.ext.commands.test_init
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests Init command.
+
+    :copyright: (c) 2015 by the Holocron Team, see AUTHORS for details.
+    :license: 3-clause BSD, see LICENSE for details.
+"""
+
+import os
+from unittest import mock
+
+from holocron.app import Holocron
+from holocron.ext.commands import init
+
+from tests import HolocronTestCase
+
+
+@mock.patch.object(os, 'curdir', '/path/to/curdir')
+class TestInitCommand(HolocronTestCase):
+
+    @mock.patch('holocron.ext.commands.init.copy_tree')
+    @mock.patch('holocron.ext.commands.init.os.listdir', return_value=[])
+    def test_curdir_was_initialized(self, _, copy_tree):
+        command = init.Init()
+        command.execute(app=mock.Mock(spec=Holocron), arguments=None)
+
+        self.assertEqual(copy_tree.call_args[0][1], '/path/to/curdir')
+
+    @mock.patch('holocron.ext.commands.init.copy_tree')
+    @mock.patch('holocron.ext.commands.init.os.listdir', return_value=['a'])
+    def test_curdir_wasnot_initialized(self, _, copy_tree):
+        command = init.Init()
+        command.execute(app=mock.Mock(spec=Holocron), arguments=None)
+
+        # it shouldn't work for non-empty directories
+        self.assertEqual(copy_tree.call_count, 0)


### PR DESCRIPTION
Currently the 'holocron init' command behaves too silent and it's not
obvious what's happened. Since now, we're printing a helpful message
about what was happened and what to do next.

Fixes #103