### PR TITLE
Fix pep8 error

### DIFF
--- a/tests/ext/generators/test_feed.py
+++ b/tests/ext/generators/test_feed.py
@@ -109,13 +109,16 @@ class TestFeedGenerator(HolocronTestCase):
         root = parsed.documentElement
 
         #: use this to sort DOM Elements from DOM Text containing \n and spaces
-        def is_element(n): return n.nodeType == n.ELEMENT_NODE
+        def is_element(n):
+            return n.nodeType == n.ELEMENT_NODE
 
         #: use this to parse <link> which contain attributes instead of values
-        def is_attribute(n): return len(n.attributes) != 0
+        def is_attribute(n):
+            return len(n.attributes) != 0
 
         #: use this to distinguish feed common elements (link, title) from post
-        def has_child(n): return len(n.childNodes) < 2
+        def has_child(n):
+            return len(n.childNodes) < 2
 
         urls = [url for url in filter(is_element, root.childNodes)]
 

--- a/tests/ext/generators/test_sitemap.py
+++ b/tests/ext/generators/test_sitemap.py
@@ -70,7 +70,8 @@ class TestSitemapGenerator(HolocronTestCase):
 
         content = {root.nodeName: []}
 
-        def is_element(n): return n.nodeType == n.ELEMENT_NODE
+        def is_element(n):
+            return n.nodeType == n.ELEMENT_NODE
 
         for url in filter(is_element, root.childNodes):
             url_data = {attr.nodeName: attr.firstChild.nodeValue


### PR DESCRIPTION
Unfortunately, the latest 'flake8' uses 'pep8 < 1.6.0' when we're waiting
for the newest version (which is greater than 1.6.0). This patch fix the
code so it's now compatible with old and new 'pep8' implementations.