### PR TITLE
Implement {here} macro support in _config.yml

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -38,7 +38,10 @@ def create_app(confpath=None):
         conf = None
         if confpath is not None:
             with open(confpath, 'r', encoding='utf-8') as f:
-                conf = yaml.load(f.read())
+                # the conf may contain the {here} macro, so we have to
+                # replace it with actual value.
+                here = os.path.dirname(os.path.abspath(confpath))
+                conf = yaml.load(f.read().format(here=here))
 
     except (FileNotFoundError, PermissionError) as exc:
         # it's ok that a user doesn't have a settings file or doesn't have

--- a/holocron/example/_config.yml
+++ b/holocron/example/_config.yml
@@ -1,19 +1,33 @@
 #
-# HOLOCRON CONFIGURATION FILE.  PLEASE DO NOT FORGET
-# TO CHANGE THE SETTINGS BELOW FOR YOURSELF. ALL THE
-# SETTINGS ARE COMMENTED FOR EASY CHANGES.
+# HOLOCRON CONFIGURATION FILE. PLEASE DO NOT FORGET TO CHANGE THE
+# SETTINGS BELOW FOR YOURSELF. ALL THE SETTINGS ARE COMMENTED FOR
+# EASY CHANGES.
 #
 # YOU CAN REMOVE UNNECESSARY SETTINGS FROM THIS FILE.
 # IN THIS CASE DEFAULT SETTINGS WILL BE USED.
 #
 
-# Here is a blog credentials. You should change it
-# on your own way.
+
 sitename:    Kenobi's Thoughts
 siteurl:     http://obi-wan.jedi
 author:      Obi-Wan Kenobi
 
+# Paths to various input / output stuff, such as where to search
+# for content and where to store built results. The {here} macro
+# will be replaced with a path to config's folder.
+paths:
+   content: {here}/
+   output:  {here}/_build
+   theme:   {here}/_theme
+
+# The place where you can customize your theme. The default one
+# supports only these settings, but third party ones may contain
+# more, so don't forget to check it out.
 theme:
    navigation: !!pairs
       - feed: /feed.xml
       - about: /about
+
+   # counters:
+   #    google_analytics: XX-XXXXXXXX-X
+   #    yandex_metrika: XXXXXXX


### PR DESCRIPTION
It's important to have some macro in _config.yml which points to
config's directory, because otherwise we are unable to handle
correctly relative paths. For instance, we have the following
_config.yml:

    paths:
       content: ./
       output: _build/

and then we want to build a blog:

    $ holocron build --conf myblog/_config.yml

It's not obvious what user wants. Does he want to search for content
in current working directory or maybe in the folder with _config.yml?

Assumption that all relative paths in _config.yml are relative to
_config.yml is a poor assumption, and it seems the most rational
fix here is to introduce some helper macros so user will be able to
do what he really wants.

So the commit introduces the {here} macro which replaces with a path
to _config.yml's directory:

    paths:
       content: {here}/
       output:  {here}/_build/