### PR TITLE
Add full tags support for posts

### DIFF
--- a/holocron/theme/templates/post.html
+++ b/holocron/theme/templates/post.html
@@ -16,4 +16,17 @@ written by {{ document.author }} on
 <time datetime="{{ document.published.isoformat() }}">
   {{ document.published.strftime('%B %d, %Y') }}
 </time>
+
+
+{% if 'tags' in generators_enabled and document.tags %}
+<div id="post-tags">
+{% for tag in document.tags %}
+    <a href="{{ tag.url }}">{{ tag.name }}</a>
+    {%- if not loop.last -%}
+        ,
+    {% endif %}
+{% endfor %}
+</div>
+{% endif %}
+
 {% endblock %}

--- a/tests/ext/generators/test_tags.py
+++ b/tests/ext/generators/test_tags.py
@@ -13,11 +13,42 @@ from unittest import mock
 from datetime import datetime
 
 from dooku.conf import Conf
-from holocron.ext.generators import tags
+from holocron.ext.generators.tags import Tags, Tag
 from holocron.content import Post, Page, Static
 from holocron.app import Holocron
 
 from tests import HolocronTestCase
+
+
+class TestTagObjects(HolocronTestCase):
+    """
+    Test tag wrapper class.
+    """
+    def setUp(self):
+        # fake tags
+        self.tag1 = 'tag1'
+        self.tag2 = 'tag2'
+
+        # some directory where all tag pages locates
+        self.tag_dir = 'test/tags'
+
+    def test_tag_name(self):
+        """
+        Test that tag object returns correct tag name.
+        """
+        tag1_obj = Tag(self.tag_dir, self.tag1)
+        tag2_obj = Tag(self.tag_dir, self.tag2)
+
+        self.assertEquals(tag1_obj.name, self.tag1)
+        self.assertEquals(tag2_obj.name, self.tag2)
+
+    def test_tag_url(self):
+        """
+        Tag object should return correct url with leading and closing slashes.
+        """
+        tag1_obj = Tag(self.tag_dir, self.tag1)
+
+        self.assertEquals(tag1_obj.url, '/test/tags/tag1/')
 
 
 class TestTagsGenerator(HolocronTestCase):
@@ -29,7 +60,7 @@ class TestTagsGenerator(HolocronTestCase):
 
     def setUp(self):
 
-        self.tags = tags.Tags(Holocron(conf=Conf({
+        self.tags = Tags(Holocron(conf=Conf({
             'sitename': 'MyTestSite',
             'siteurl': 'www.mytest.com',
             'author': 'Tester',
@@ -108,7 +139,7 @@ class TestTagsGenerator(HolocronTestCase):
 
             return content
 
-    def test_tags_with_posts(self):
+    def test_tag_template_building(self):
         """
         Test that tags function writes a post to a tag template.
         """
@@ -151,7 +182,7 @@ class TestTagsGenerator(HolocronTestCase):
 
         self.assertEqual('path/to/output/mypath/tags/testtag3', content[2][2])
 
-    def test_mixed_documents(self):
+    def test_sorting_out_mixed_documents(self):
         """
         Test that Tags sorts out post documents from documents of other types.
         """
@@ -160,3 +191,11 @@ class TestTagsGenerator(HolocronTestCase):
 
         self.assertIn(self.h_year(2014), content)
         self.assertIn('<a href="www.post_late.com">', content)
+
+    def test_posts_patching_with_tag_objects(self):
+        posts = [self.post_late]
+
+        self._get_tags_content(posts)
+
+        self.assertEquals(self.post_late.tags[0].name, 'testtag2')
+        self.assertEquals(self.post_late.tags[0].url, '/mypath/tags/testtag2/')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -139,21 +139,21 @@ class TestHolocron(HolocronTestCase):
         iterfiles.assert_called_with(
             self.app.conf['paths']['content'], '[!_.]*', True)
 
-        self.app.__class__.document_factory.assert_has_calls([
-            # check that document class was used to generate class instances
-            mock.call('doc_a', self.app),
-            # check that document instances were built
-            mock.call().build(),
-            mock.call('doc_b', self.app),
-            mock.call().build(),
-            mock.call('doc_c', self.app),
-            mock.call().build(),
-        ])
-        self.assertEqual(self.app.__class__.document_factory.call_count, 3)
-
         # check that generators was used
         for _, generator in self.app._generators.items():
             self.assertEqual(generator.generate.call_count, 1)
+
+        self.app.__class__.document_factory.assert_has_calls([
+            # check that document class was used to generate class instances
+            mock.call('doc_a', self.app),
+            mock.call('doc_b', self.app),
+            mock.call('doc_c', self.app),
+            # check that document instances were built
+            mock.call().build(),
+            mock.call().build(),
+            mock.call().build(),
+        ])
+        self.assertEqual(self.app.__class__.document_factory.call_count, 3)
 
         # check that _copy_theme was called
         self.app._copy_theme.assert_called_once_with()


### PR DESCRIPTION
Posts now contain a tag object instead of a simple string. The object provides
a tag name as a string and build a url for tag. We patch the posts with those
objects before the documents are built.

Fixed #93