### PR TITLE
Implement blog builder in serve command

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -129,7 +129,8 @@ class Holocron(object):
         'commands': {
             'serve': {
                 'host': '0.0.0.0',
-                'port': '5000',
+                'port': 5000,
+                'wakeup': 1,
             },
         },
     }


### PR DESCRIPTION
In order to share recreated Holocron instance between filesystem watchers
and prevent application build trigger on events spam, the Builder class
was implemented. The Builder is a thread that waked up each N seconds
(default: 1 sec) and recreate/rebuild blog if needed.

Signed-off-by: Igor Kalnitsky <igor@kalnitsky.org>