### PR TITLE
Gather site related options in one node

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -88,9 +88,12 @@ class Holocron(object):
 
     #: Default settings.
     default_conf = {
-        'sitename': 'Obi-Wan Kenobi',
-        'siteurl': 'http://obi-wan.jedi',
-        'author': 'Obi-Wan Kenobi',
+        'site': {
+            'title': 'Obi-Wan Kenobi',
+            'subtitle': None,
+            'url': 'http://obi-wan.jedi',
+            'author': 'Obi-Wan Kenobi',
+        },
 
         'encoding': {
             'content': 'utf-8',
@@ -218,9 +221,7 @@ class Holocron(object):
         env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders))
         env.globals.update(
             # pass some useful conf options to the template engine
-            sitename=self.conf['sitename'],
-            siteurl=self.conf['siteurl'],
-            author=self.conf['author'],
+            site=self.conf['site'],
             theme=self.conf['theme'],
             encoding=self.conf['encoding.output'],
             generators_enabled=self.conf['generators.enabled'])

--- a/holocron/content.py
+++ b/holocron/content.py
@@ -94,7 +94,7 @@ class Document(metaclass=abc.ABCMeta):
         self.updated_local = self.updated.astimezone(Local)
 
         #: an absolute url to the built document
-        self.abs_url = self._app.conf['siteurl'] + self.url
+        self.abs_url = self._app.conf['site.url'] + self.url
 
     @abc.abstractmethod
     def build(self):
@@ -144,7 +144,7 @@ class Page(Document):
         super().__init__(*args, **kwargs)
 
         # set default author (if none was specified in the document)
-        self.author = self._app.conf['author']
+        self.author = self._app.conf['site.author']
 
         # set extracted information and override default one
         meta = self._parse_document()
@@ -187,10 +187,7 @@ class Page(Document):
         encoding = self._app.conf['encoding.output']
 
         with open(destination, 'w', encoding=encoding) as f:
-            f.write(template.render(
-                document=self,
-                sitename=self._app.conf['sitename'],
-                siteurl=self._app.conf['siteurl'], ))
+            f.write(template.render(document=self))
 
     @cached_property
     def url(self):

--- a/holocron/example/_config.yml
+++ b/holocron/example/_config.yml
@@ -8,9 +8,11 @@
 #
 
 
-sitename:    Kenobi's Thoughts
-siteurl:     http://obi-wan.jedi
-author:      Obi-Wan Kenobi
+site:
+   title:      Kenobi's Thoughts
+   subtitle:   the Force techniques
+   url:        http://obi-wan.jedi
+   author:     Obi-Wan Kenobi
 
 # Paths to various input / output stuff, such as where to search
 # for content and where to store built results. The {here} macro

--- a/holocron/theme/templates/base.html
+++ b/holocron/theme/templates/base.html
@@ -16,14 +16,14 @@
   <link rel="stylesheet" href="/static/holocron.css">
   <link rel="stylesheet" href="/static/pygments.css">
 
-  <title>{% block title %}{{ sitename }}{% endblock title %}</title>
+  <title>{% block title %}{{ site.title }}{% endblock title %}</title>
 
 <body>
 
   <div class="header-wrapper">
   <header class="header">
     <img src="/static/logo.png" alt="Logotype" class="logo">
-    <h1><a href="/">{{ sitename }}</a></h1>
+    <h1><a href="/">{{ site.title }}</a></h1>
 
     <nav>
     {% if theme.navigation -%}
@@ -48,7 +48,7 @@
       Content is licensed under the <br>
       Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License
     </p>
-    <p>&copy; 2014, {{ author }}</p>
+    <p>&copy; 2014, {{ site.author }}</p>
   </footer>
   </div> <!-- /.footer-wrapper -->
 

--- a/holocron/theme/templates/document-list.html
+++ b/holocron/theme/templates/document-list.html
@@ -10,8 +10,6 @@
 
 {% extends "base.html" %}
 
-{% block title %}{{ sitename }}{% endblock %}
-
 
 {% block content %}
 

--- a/holocron/theme/templates/page.html
+++ b/holocron/theme/templates/page.html
@@ -9,7 +9,7 @@
 -#}
 {% extends "base.html" %}
 
-{% block title %}{{ document.title }} | {{ sitename }}{% endblock %}
+{% block title %}{{ document.title }} | {{ site.title }}{% endblock %}
 
 
 {% block content %}

--- a/tests/ext/generators/test_feed.py
+++ b/tests/ext/generators/test_feed.py
@@ -29,9 +29,11 @@ class TestFeedGenerator(HolocronTestCase):
     def setUp(self):
 
         self.feed = feed.Feed(Holocron(conf=Conf({
-            'sitename': 'MyTestSite',
-            'siteurl': 'www.mytest.com',
-            'author': 'Tester',
+            'site': {
+                'title': 'MyTestSite',
+                'author': 'Tester',
+                'url': 'http://www.mytest.com/',
+            },
 
             'encoding': {
                 'output': 'my-enc',
@@ -183,7 +185,7 @@ class TestFeedGenerator(HolocronTestCase):
 
         feed = content['feed']
 
-        self.assertEqual('MyTestSite Feed', feed['title'])
+        self.assertEqual('MyTestSite', feed['title'])
         self.assertEqual('http://www.mytest.com/', feed['id'])
         self.assertEqual('http://www.mytest.com/myfeed.xml', feed['link.self'])
         self.assertEqual('http://www.mytest.com/', feed['link.alternate'])

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -30,7 +30,9 @@ class DocumentTestCase(HolocronTestCase):
     _getmtime = 1420121400  # UTC: 2015/01/01 2:10pm
 
     _fake_conf = Conf(app.Holocron.default_conf, {
-        'siteurl': 'http://example.com',
+        'site': {
+            'url': 'http://example.com',
+        },
         'encoding': {
             'content': 'cont-enc',
             'output': 'out-enc',
@@ -193,7 +195,7 @@ class TestPage(DocumentTestCase):
         with mock.patch(self._open_fn, mopen, create=True):
             super(TestPage, self).setUp()
 
-        self.assertEqual(self.doc.author, self._fake_conf['author'])
+        self.assertEqual(self.doc.author, self._fake_conf['site.author'])
         self.assertEqual(self.doc.template, self.document_class.template)
         self.assertEqual(self.doc.title, self.document_class.title)
 


### PR DESCRIPTION
Currently we have a set of top-level settings:

* sitename
* siteurl
* author

and it becomes painful to pass them one-by-one into various place (e.g.
template engine). Since now, we have one top-level setting node - 'site'
- which contains all these settings and introduces a new one - 'subtitle'.

  site:
     title: ...
     subtitle: ...
     author: ...
     url: ...

Signed-off-by: Igor Kalnitsky <igor@kalnitsky.org>