### PR TITLE
Rethink extensions design

### DIFF
--- a/holocron/content.py
+++ b/holocron/content.py
@@ -141,7 +141,7 @@ class Page(Document):
     title = 'Untitled'
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(Page, self).__init__(*args, **kwargs)
 
         # set default author (if none was specified in the document)
         self.author = self._app.conf['site.author']
@@ -216,7 +216,7 @@ class Post(Page):
     template = 'post.html'
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(Post, self).__init__(*args, **kwargs)
 
         published = ''.join(self.short_source.split(os.sep)[:3])
         published = datetime.datetime.strptime(published, '%Y%m%d')

--- a/holocron/ext/abc.py
+++ b/holocron/ext/abc.py
@@ -21,13 +21,15 @@ class Command(object, metaclass=abc.ABCMeta):
     They could be used to build application (generate html blog entries),
     serve the application at a local webserver or online, etc.
 
-    Usage example::
+    Example::
 
         from holocron.ext import abc
 
         class MyCoolCommand(abc.Command):
             def execute(self, app):
                 # perform some actions
+
+    TODO: revise the docstring
     """
 
     def set_arguments(self, parser):
@@ -51,14 +53,13 @@ class Command(object, metaclass=abc.ABCMeta):
 
 class Converter(object, metaclass=abc.ABCMeta):
     """
-    Abstract base class for 'Converter' extensions.
+    The 'Converter' interface.
 
     Holocron converters hierarchy originates here. In the best traditions
-    of the classical OOP, the class declares the converter interface, which
+    of the classical OOP, the class declares a converter interface, which
     has to be respected by all converters.
 
-    So in case you want to write your own converter, you probably write
-    something like that::
+    Example::
 
         from holocron.ext import abc
 
@@ -69,25 +70,7 @@ class Converter(object, metaclass=abc.ABCMeta):
                 # do conversion
                 return meta, html
 
-    It's important to note, that a converter in terms of extension is not
-    a converter in terms of application:
-
-    * in terms of extension, the converter is an extension class, which
-      registers a convert function in a given application instance;
-
-    * in terms of application, the converter is a convert function, that
-      can convert a given markuped text into HTML and extract some meta
-      information.
-
-    Converters receive a conf dictionary as a constructor argument that
-    is extracted from `converters` node of your YAML settings file.
-
-    :param conf: a :class:`~dooku.conf.Conf` with converters settings;
-                 it's a good practice to use a separate setting-node for
-                 each converter
     """
-    def __init__(self, conf):
-        self.conf = conf
 
     @property
     @abc.abstractmethod
@@ -112,12 +95,13 @@ class Converter(object, metaclass=abc.ABCMeta):
 
 class Generator(object, metaclass=abc.ABCMeta):
     """
-    Abstract base class for 'Generator' extensions.
+    The 'Generator' interface.
 
-    Generators are a special kind of Holocron extensions. They're designed to
-    generate helpful stuff based on input document collection (e.g. sitemap).
+    Generators are a special kind of Holocron extensions. They're designed
+    to generate additional stuff based on input document collection. Good
+    examples of generators are feed and sitemap.
 
-    Usage example::
+    Example::
 
         from holocron.ext import abc
 
@@ -125,10 +109,7 @@ class Generator(object, metaclass=abc.ABCMeta):
             def generate(self, documents):
                 # do some job based on input document collection
 
-    :param app: an application instance
     """
-    def __init__(self, app):
-        self.app = app
 
     @abc.abstractmethod
     def generate(self, documents):

--- a/holocron/ext/generators/feed.py
+++ b/holocron/ext/generators/feed.py
@@ -14,6 +14,7 @@ import datetime
 import textwrap
 
 import jinja2
+from dooku.conf import Conf
 
 from holocron.ext import abc
 from holocron.utils import normalize_url, mkdir
@@ -22,13 +23,34 @@ from holocron.content import Post
 
 class Feed(abc.Generator):
     """
-    This class is designed to generate a site feed - content distribution
-    technology - in Atom format.
+    An Atom feed generator.
 
-    The Atom specification: http://www.ietf.org/rfc/rfc4287.txt
+    This class is a generator extension that is designed to generate a site
+    feed - content distribution technology - in the `Atom`_  format.
+    See the :class:`~holocron.ext.Generator` class for interface details.
+
+    The generator has several options::
+
+        ext:
+           feed:
+              save_as: feed.xml
+              posts_number: 5
+
+    where
+
+    * ``save_as`` is a path to output file relative to output directory
+    * ``posts_number`` is a number of latest post to be shown in feed
+
+    The class is actually both extension and generator in terms of Holocron
+    at one time. It means that this class will be discovered by Holocron as
+    extension, and this class register its instance as generator in the
+    application.
+
+    .. _Atom: http://www.ietf.org/rfc/rfc4287.txt
+
+    :param app: an application instance for which we're creating extension
     """
 
-    #: an atom template
     _template = jinja2.Template(textwrap.dedent('''\
         <?xml version="1.0" encoding="{{ encoding }}"?>
           <feed xmlns="http://www.w3.org/2005/Atom" >
@@ -62,25 +84,45 @@ class Feed(abc.Generator):
             {% endfor %}
           </feed>'''))
 
-    def generate(self, documents):
-        posts = (doc for doc in documents if isinstance(doc, Post))
-        posts = sorted(posts, key=lambda d: d.published, reverse=True)
+    _default_conf = {
+        'save_as': 'feed.xml',
+        'posts_number': 5,
+    }
 
-        posts_number = self.app.conf['generators.feed.posts_number']
-        save_as = self.app.conf['generators.feed.save_as']
+    def __init__(self, app):
+        super(Feed, self).__init__()
+
+        self._appconf = app.conf
+        self._conf = Conf(self._default_conf, app.conf.get('ext.feed', {}))
+
+        app.add_generator(self)
+
+    def generate(self, documents):
+        posts_number = self._conf['posts_number']
+        save_as = self._conf['save_as']
+
+        # we are interested only in 'post' documents because 'pages'
+        # usually are not a part of feed since they are not intended
+        # to deliver content with regular updates
+        posts = (doc for doc in documents if isinstance(doc, Post))
+
+        # since we could have a lot of posts, it's a common practice to
+        # use in feed only last N posts
+        posts = sorted(posts, key=lambda d: d.published, reverse=True)
+        posts = posts[:posts_number]
 
         credentials = {
-            'siteurl_self': normalize_url(self.app.conf['site.url']) + save_as,
-            'siteurl_alt': normalize_url(self.app.conf['site.url']),
-            'site': self.app.conf['site'],
+            'siteurl_self': normalize_url(self._appconf['site.url']) + save_as,
+            'siteurl_alt': normalize_url(self._appconf['site.url']),
+            'site': self._appconf['site'],
             'date': datetime.datetime.utcnow().replace(microsecond=0), }
 
-        save_as = os.path.join(self.app.conf['paths.output'], save_as)
+        save_as = os.path.join(self._appconf['paths.output'], save_as)
         mkdir(os.path.dirname(save_as))
-        encoding = self.app.conf['encoding.output']
+        encoding = self._appconf['encoding.output']
 
         with open(save_as, 'w', encoding=encoding) as f:
             f.write(self._template.render(
-                documents=posts[:posts_number],
+                documents=posts,
                 credentials=credentials,
                 encoding=encoding))

--- a/holocron/ext/generators/index.py
+++ b/holocron/ext/generators/index.py
@@ -11,31 +11,60 @@
 
 import os
 
+from dooku.conf import Conf
+
 from holocron.ext import abc
 from holocron.content import Post
 
 
 class Index(abc.Generator):
     """
-    Generates an index page - page which lists all posts in a blog. This page
-    will be stored in the root of the output folder.
+    An index page generator.
+
+    This class is a generator extension that is designed to generate an
+    index page of the web site - the page that lists all posts of a blog.
+    The index page is stored stored in the root of the output folder.
+    See the :class:`~holocron.ext.Generator` class for interface details.
+
+    The generator has just one option::
+
+        ext:
+           index:
+              template: document-list.html
+
+    where
+
+    * ``templates`` is a template name to be used for rendering index page
+
+    The class is actually both extension and generator in terms of Holocron
+    at one time. It means that this class will be discovered by Holocron as
+    extension, and this class register its instance as generator in the
+    application.
+
+    :param app: an application instance for which we're creating extension
     """
 
-    #: a template name to be used for rendering index page
-    _template_name = 'document-list.html'
+    _default_conf = {
+        'template': 'document-list.html',
+    }
 
-    #: a filename to be used for html output file
-    _save_as = 'index.html'
+    def __init__(self, app):
+        super(Index, self).__init__()
+
+        self._conf = Conf(self._default_conf, app.conf.get('ext.index', {}))
+        self._encoding = app.conf['encoding.output']
+        self._template = app.jinja_env.get_template(self._conf['template'])
+        # An output filename. Why this? Because we want to see this page
+        # by typing site url in a browser and http servers are usually
+        # looking for this file if none was specified.
+        self._save_as = os.path.join(app.conf['paths.output'], 'index.html')
+
+        app.add_generator(self)
 
     def generate(self, documents):
+        # we are interested only in posts, because pages usually are
+        # shown in a some sort of navigation bar
         posts = (doc for doc in documents if isinstance(doc, Post))
 
-        #: output path for index page
-        save_as = os.path.join(self.app.conf['paths.output'], self._save_as)
-        encoding = self.app.conf['encoding.output']
-
-        #: load template for rendering index page
-        _template = self.app.jinja_env.get_template(self._template_name)
-
-        with open(save_as, 'w', encoding=encoding) as f:
-            f.write(_template.render(posts=posts))
+        with open(self._save_as, 'w', encoding=self._encoding) as f:
+            f.write(self._template.render(posts=posts))

--- a/holocron/theme/templates/post.html
+++ b/holocron/theme/templates/post.html
@@ -18,7 +18,7 @@ written by {{ document.author }} on
 </time>
 
 
-{% if 'tags' in generators_enabled and document.tags %}
+{% if show_tags and document.tags %}
 <div class="post-tags">
 tagged with
 {% for tag in document.tags %}

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools import setup, find_packages
 from holocron import __version__ as holocron_version
 from holocron import __license__ as holocron_license
 
+
 setup(
     name='holocron',
     version=holocron_version,
@@ -40,11 +41,9 @@ setup(
             'holocron = holocron.main:main',
         ],
 
-        'holocron.ext.converters': [
+        'holocron.ext': [
             'markdown = holocron.ext.converters.markdown:Markdown',
-        ],
 
-        'holocron.ext.generators': [
             'feed = holocron.ext.generators.feed:Feed',
             'index = holocron.ext.generators.index:Index',
             'sitemap = holocron.ext.generators.sitemap:Sitemap',

--- a/tests/ext/converters/test_markdown.py
+++ b/tests/ext/converters/test_markdown.py
@@ -9,29 +9,45 @@
     :license: 3-clause BSD, see LICENSE for details.
 """
 
+import textwrap
+
+from holocron.app import Holocron
 from holocron.ext.converters import markdown
 
-from dooku.conf import Conf
 from tests import HolocronTestCase
 
 
 class TestMarkdownConverter(HolocronTestCase):
+    """
+    Test Markdown converter.
+    """
 
     def setUp(self):
-        self.conv = markdown.Markdown(Conf({
-            'markdown': {
-                'extensions': [], }}))
+        self.conv = markdown.Markdown(Holocron(conf={
+            'ext': {
+                'markdown': {
+                    'extensions': [],
+                },
+            },
+        }))
 
     def test_markdown_simple_post(self):
-        meta, html = self.conv.to_html(
-            '# some title\n'
-            '\n'
-            'some text with **bold**\n')
+        """
+        Markdown function has to fucking work.
+        """
+        meta, html = self.conv.to_html(textwrap.dedent('''\
+            # some title
+
+            some text with **bold**
+        '''))
 
         self.assertEqual(meta['title'], 'some title')
         self.assertEqual(html, '<p>some text with <strong>bold</strong></p>')
 
     def test_markdown_without_title(self):
+        """
+        Converter has to work even if there's no title in the document.
+        """
         meta, html = self.conv.to_html(
             'some text with **bold** and *italic*\n')
 
@@ -40,13 +56,68 @@ class TestMarkdownConverter(HolocronTestCase):
             '<p>some text with <strong>bold</strong> and <em>italic</em></p>'))
 
     def test_markdown_codehilite_extension(self):
-        self.conv = markdown.Markdown(Conf({
-            'markdown': {
-                'extensions': ['codehilite', 'extra'], }}))
+        """
+        Converter has to use Pygments to highlight code blocks.
+        """
+        self.conv = markdown.Markdown(Holocron(conf={
+            'ext': {
+                'markdown': {
+                    'extensions': ['codehilite'],
+                },
+            },
+        }))
 
-        _, html = self.conv.to_html(
-            '```python\n'
-            'lambda x: pass\n'
-            '```\n')
+        _, html = self.conv.to_html(textwrap.dedent('''\
+            test codeblock
+
+                :::python
+                lambda x: pass
+        '''))
 
         self.assertIn('codehilite', html)
+
+    def test_markdown_extra_code(self):
+        """
+        Converter has to support GitHub's fence code syntax.
+        """
+        self.conv = markdown.Markdown(Holocron(conf={
+            'ext': {
+                'markdown': {
+                    'extensions': ['codehilite', 'extra'],
+                },
+            },
+        }))
+
+        _, html = self.conv.to_html(textwrap.dedent('''\
+            ```python
+            lambda x: pass
+            ```
+        '''))
+
+        self.assertIn('codehilite', html)
+
+    def test_markdown_extra_tables(self):
+        """
+        Converter has to support tables syntax.
+        """
+        self.conv = markdown.Markdown(Holocron(conf={
+            'ext': {
+                'markdown': {
+                    'extensions': ['extra'],
+                },
+            },
+        }))
+
+        _, html = self.conv.to_html(textwrap.dedent('''\
+            column a | column b
+            ---------|---------
+               foo   |   bar
+        '''))
+
+        self.assertIn('table', html)
+
+        self.assertIn('<th>column a</th>', html)
+        self.assertIn('<th>column b</th>', html)
+
+        self.assertIn('<td>foo</td>', html)
+        self.assertIn('<td>bar</td>', html)

--- a/tests/ext/generators/test_feed.py
+++ b/tests/ext/generators/test_feed.py
@@ -27,7 +27,6 @@ class TestFeedGenerator(HolocronTestCase):
     """
 
     def setUp(self):
-
         self.feed = feed.Feed(Holocron(conf=Conf({
             'site': {
                 'title': 'MyTestSite',
@@ -43,7 +42,8 @@ class TestFeedGenerator(HolocronTestCase):
                 'output': 'path/to/output',
             },
 
-            'generators': {
+            'ext': {
+                'enabled': ['feed'],
 
                 'feed': {
                     'save_as': 'myfeed.xml',
@@ -204,9 +204,9 @@ class TestFeedGenerator(HolocronTestCase):
         """
         Feed function has to fucking work.
         """
-        #: here we require only one post to test its content correctness
-        #: we test posts in other test suites
-        self.feed.app.conf['generators.feed.posts_number'] = 1
+        # here we require only one post to test its content correctness
+        # we test posts in other test suites
+        self.feed._conf['posts_number'] = 1
 
         content = self._get_content([self.post_early, self.post_late])
         content = self._xml_to_dict(content)

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -55,10 +55,11 @@ class DocumentTestCase(HolocronTestCase):
         """
         filename = os.path.join(
             self._fake_conf['paths.content'], self.document_filename)
+        self._fake_app = mock.Mock(conf=self._fake_conf)
 
         self.doc = self.document_class(filename, mock.Mock(
             _converters={
-                '.mdown': markdown.Markdown(self._fake_conf['converters']), },
+                '.mdown': markdown.Markdown(self._fake_app), },
             conf=self._fake_conf))
 
 


### PR DESCRIPTION
From now on we have just one extension type. Technically, an extension is
a some callable that receives a Holocron instance and is exported to
holocron.ext namespace by setup.py. In order to extend Holocron in some
way, an extension should, for exampke, register either converter or
generator or even both in the application instance.

Each extension has its own default settings, so we don't have ext
defaults in core settings now.

Fixed #94