### PR TITLE
Implement 'add_theme_ctx` for Holocron instance

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -177,6 +177,18 @@ class Holocron(object):
         """
         self._generators.append(generator)
 
+    def add_theme_ctx(self, **kwargs):
+        """
+        Pass given keyword arguments to theme templates.
+        """
+        overwritten = set(kwargs.keys()) & set(self.jinja_env.globals.keys())
+        if overwritten:
+            logger.warning(
+                'the following theme context is going to be overwritten: %s',
+                ', '.join(overwritten))
+
+        self.jinja_env.globals.update(**kwargs)
+
     @cached_property
     def jinja_env(self):
         """

--- a/holocron/ext/generators/feed.py
+++ b/holocron/ext/generators/feed.py
@@ -94,8 +94,10 @@ class Feed(abc.Generator):
 
         self._appconf = app.conf
         self._conf = Conf(self._default_conf, app.conf.get('ext.feed', {}))
+        self._url = normalize_url(app.conf['site.url']) + self._conf['save_as']
 
         app.add_generator(self)
+        app.add_theme_ctx(feedurl=self._url)
 
     def generate(self, documents):
         posts_number = self._conf['posts_number']
@@ -112,7 +114,7 @@ class Feed(abc.Generator):
         posts = posts[:posts_number]
 
         credentials = {
-            'siteurl_self': normalize_url(self._appconf['site.url']) + save_as,
+            'siteurl_self': self._url,
             'siteurl_alt': normalize_url(self._appconf['site.url']),
             'site': self._appconf['site'],
             'date': datetime.datetime.utcnow().replace(microsecond=0), }

--- a/holocron/ext/generators/tags.py
+++ b/holocron/ext/generators/tags.py
@@ -71,8 +71,8 @@ class Tags(abc.Generator):
         self._save_as = os.path.join(
             app.conf['paths.output'], self._conf['output'], 'index.html')
 
-        app.jinja_env.globals.update(show_tags=True)
         app.add_generator(self)
+        app.add_theme_ctx(show_tags=True)
 
     def generate(self, documents):
         # we are interested only in 'post' documents because 'pages'

--- a/holocron/theme/templates/base.html
+++ b/holocron/theme/templates/base.html
@@ -13,8 +13,12 @@
   <meta charset="{{ encoding }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="stylesheet" href="/static/style.css">
-  <link rel="stylesheet" href="/static/pygments.css">
+  <link rel="stylesheet" type="text/css" href="/static/style.css">
+  <link rel="stylesheet" type="text/css" href="/static/pygments.css">
+
+  {% if feedurl -%}
+  <link rel="alternate" type="application/atom+xml" href="{{ feedurl }}" title="{{ site.title }}">
+  {%- endif %}
 
   <title>{% block title %}{{ site.title }}{% endblock title %}</title>
 


### PR DESCRIPTION
It's important to have a public way to pass some data to theme
templates. For instance, such thing like Feed generator wants
to pass the feed link to templates.

Fixed #53