### PR TITLE
Implement ribbon feature for default theme

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -89,7 +89,7 @@ class Holocron(object):
     #: Default settings.
     default_conf = {
         'site': {
-            'title': "Kenobi's Thought",
+            'title': "Kenobi's Thoughts",
             'author': 'Obi-Wan Kenobi',
             'url': 'http://obi-wan.jedi',
         },

--- a/holocron/example/_config.yml
+++ b/holocron/example/_config.yml
@@ -32,3 +32,7 @@ theme:
    # counters:
    #    google_analytics: XX-XXXXXXXX-X
    #    yandex_metrika: XXXXXXX
+
+   # ribbon:
+   #    text:  Star On GitHub
+   #    link:  https://github.com/ikalnitsky/kalnitsky.org

--- a/holocron/theme/static/style.css
+++ b/holocron/theme/static/style.css
@@ -98,7 +98,7 @@ header.header nav a {
    -------------------------------------------------------------------- */
 
 footer.footer {
-  border-top: 1px solid #E0e0e0;
+  border-top: 1px solid #e0e0e0;
   font-size: 0.8em;
   line-height: 1.4em;
   text-align: center;
@@ -231,6 +231,50 @@ footer.footer p {
   text-align: center;
 }
 
+
+/* --------------------------------------------------------------------
+    github banner
+   -------------------------------------------------------------------- */
+
+.ribbon-wrapper {
+  font-size: 14px;
+  width: 18em;
+  height: 18em;
+  position: absolute;
+  top: 0;
+  right: 0;
+  overflow: hidden;
+}
+.ribbon {
+  color: #2f5a8b;
+  border: 1px dotted #2f5a8b;
+  background-color: #f0f0f8;
+  text-decoration: none;
+  white-space: nowrap;
+  font-weight: bold;
+  text-transform: uppercase;
+  text-align: center;
+
+  /* math magic for positioning :) */
+  display: block;
+  position: relative;
+  top: 4em;
+  right: -2em;
+  width: 100%;
+  padding: 0.4em 1em;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+.ribbon:hover {
+  background-color: #e8e8f8;
+  text-decoration: none;
+}
+
+
 /* --------------------------------------------------------------------
     hacks for responsive design
    -------------------------------------------------------------------- */
@@ -239,6 +283,8 @@ footer.footer p {
   /* let's use much smaller padding for small displays */
   .header-wrapper, .footer-wrapper { padding: 0em 0.5em; }
   .content-wrapper { padding: 0em 1em; }
+  /* do not show github banner */
+  .ribbon { display: none; }
 }
 
 

--- a/holocron/theme/templates/base.html
+++ b/holocron/theme/templates/base.html
@@ -50,4 +50,10 @@
   </footer>
   </div> <!-- /.footer-wrapper -->
 
+  {% if theme.ribbon %}
+  <div class="ribbon-wrapper">
+    <a href="{{ theme.ribbon.link }}" class="ribbon">{{ theme.ribbon.text }}</a>
+  </div>
+  {% endif %}
+
 {% include 'counters.html' %}


### PR DESCRIPTION
Many developers host their blogs on GitHub and use a 'Fork on GitHub'
ribbon to link to sources. This commit implements an abstact ribbon for
the default theme. It could be enabled by setting a special option in
the _config.yml:

    ribbon:
       text:    text to be shown
       link:    link to be visited

Fixed #37