### PR TITLE
Remove hardcoded copyright notice from theme

### DIFF
--- a/holocron/example/_config.yml
+++ b/holocron/example/_config.yml
@@ -36,3 +36,5 @@ theme:
    # ribbon:
    #    text:  Star On GitHub
    #    link:  https://github.com/ikalnitsky/kalnitsky.org
+
+   # copyright:  &copy; 19 BBY, Obi-Wan Kenobi

--- a/holocron/theme/static/style.css
+++ b/holocron/theme/static/style.css
@@ -99,16 +99,16 @@ header.header nav a {
 
 footer.footer {
   border-top: 1px solid #e0e0e0;
+  padding: 0.5em 0em 3em;
   font-size: 0.8em;
-  line-height: 1.4em;
+  line-height: 1.5em;
   text-align: center;
   color: #777777;
 }
 
 footer.footer p {
-  margin: 0.7em 0;
+  margin: 0.5em 0;
 }
-
 
 /* --------------------------------------------------------------------
     posts / pages

--- a/holocron/theme/templates/base.html
+++ b/holocron/theme/templates/base.html
@@ -46,11 +46,7 @@
 
   <div class="footer-wrapper">
   <footer class="footer">
-    <p>
-      Content is licensed under the <br>
-      Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License
-    </p>
-    <p>&copy; 2014, {{ site.author }}</p>
+    <p>{{ theme.copyright }}</p>
   </footer>
   </div> <!-- /.footer-wrapper -->
 


### PR DESCRIPTION
It's quite a bad idea to have hardcoded license and copyright notice in
the base theme template. User may want to use another license or specify
entire notice in his own way.

Since now we have a theme's option - 'copyright' - by means which user
may specify his own notice. Example:

    theme:
       copyright: (c) 2014, Igor Kalnitsky

It's important to note that the option supports multilined strings and
HTML tags.