### PR TITLE
Improve Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
+sudo: false
 language: python
+
 python:
   - "3.4"
-
-branches:
-  only:
-    - master
-
-os:
-  - linux
-  - osx
 
 install:
   - pip install tox coveralls


### PR DESCRIPTION
1. Use container-based infra on Travis CI

   Since we run only unit tests in Holocron, it's better to use
   container-based infrastructure on Travis CI. Why? Because it
   provides:

   * fast start up (no need to wait for free vm)
   * ability the use caches

   http://docs.travis-ci.com/user/workers/container-based-infrastructure/

2. Run builds not only for master branch

   Honestly, I don't know why it was so, but there are no reasons why
   we shouldn't run CI for other branches.

3. Remove OS X builds

   Currently there's no python setup for OS X. Moreover, the feature
   is completely experimental and turned off by default. If it doesn't
   work now, so why do we have it config? :)