### PR TITLE
Fix small tags parsing problem

### DIFF
--- a/holocron/ext/generators/tags.py
+++ b/holocron/ext/generators/tags.py
@@ -10,6 +10,7 @@
 """
 
 import os
+import logging
 from collections import defaultdict
 
 from dooku.conf import Conf
@@ -17,6 +18,9 @@ from dooku.conf import Conf
 from holocron.ext import abc
 from holocron.content import Post
 from holocron.utils import mkdir
+
+
+logger = logging.getLogger(__name__)
 
 
 class Tag(object):
@@ -84,6 +88,13 @@ class Tags(abc.Generator):
 
         for post in posts:
             if hasattr(post, 'tags'):
+
+                if not isinstance(post.tags, (list, tuple)):
+                    logger.warning(
+                        'Tags must be wrapped with list or tuple in %s',
+                        post.short_source)
+                    continue
+
                 tag_objects = []
                 for tag in post.tags:
                     tags[tag].append(post)

--- a/tests/ext/generators/test_tags.py
+++ b/tests/ext/generators/test_tags.py
@@ -104,6 +104,11 @@ class TestTagsGenerator(HolocronTestCase):
             url='www.post_late.com',
             tags=['testtag2'])
 
+        self.post_malformed = mock.Mock(
+            spec=Post,
+            short_source='test',
+            tags='testtag')
+
         self.page = mock.Mock(spec=Page)
         self.static = mock.Mock(spec=Static)
 
@@ -231,3 +236,12 @@ class TestTagsGenerator(HolocronTestCase):
 
         err = 'Could not find link for #tag2.'
         self.assertIn('<a href="/mypath/tags/tag2/">#tag2</a>', content, err)
+
+    @mock.patch('holocron.ext.generators.tags.mkdir')
+    def test_malformed_tags_are_skipped(self, mock_mkdir):
+        """
+        Test if tags formatting is correct.
+        """
+        content = self._get_tags_content([self.post_malformed])
+
+        self.assertEqual(content, [])


### PR DESCRIPTION
Introduce a check for the tags format. If tags are not specified in the square
brackets, tags generator won't be run on them and warning will be printed.

Fixed #29