### PR TITLE
Add parsing of holocron command w/o arguments

### DIFF
--- a/holocron/main.py
+++ b/holocron/main.py
@@ -98,7 +98,19 @@ def parse_command_line(args, commands):
         subparser = command_parser.add_parser(name)
         command.set_arguments(subparser)
 
-    return parser.parse_args(args)
+    # parse cli and form arguments object
+    arguments = parser.parse_args(args)
+
+    # if no commands are specified display help
+    if arguments.command is None:
+        parser.print_help()
+        parser.exit(1)
+
+    # this hack's used to bypass lack of user's config file when init invoked
+    if arguments.command in ('init', ):
+        arguments.conf = None
+
+    return arguments
 
 
 def main(args=sys.argv[1:]):
@@ -110,10 +122,6 @@ def main(args=sys.argv[1:]):
     # initial logger configuration - use custom format for records
     # and print records with WARNING level and higher.
     configure_logger(arguments.verbosity or logging.WARNING)
-
-    # this hack's used to bypass lack of user's config file when init invoked
-    if arguments.command in ('init', ):
-        arguments.conf = None
 
     # create app instance
     holocron = create_app(arguments.conf)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,7 +15,7 @@ from unittest import mock
 from dooku.ext import ExtensionManager
 
 from holocron.app import Holocron
-from holocron.main import main
+from holocron.main import main, parse_command_line
 
 from tests import HolocronTestCase
 
@@ -106,3 +106,11 @@ class TestCli(HolocronTestCase):
         main(['cmd1'])
 
         sys_exit.assert_called_once_with(1)
+
+    @mock.patch('holocron.main.argparse.ArgumentParser.print_help')
+    @mock.patch('holocron.main.argparse.ArgumentParser.exit')
+    def test_just_parent_command(self, exit, help):
+        parse_command_line([], {})
+
+        help.assert_called_once_with()
+        exit.assert_called_once_with(1)


### PR DESCRIPTION
Motivation behind this patch is to avoid printing strange exceptions
when running holocron command without arguments.
````bash
$ holocron
Traceback (most recent call last):
  File "/home/propheticbird/Projects/holocron/venv/bin/holocron", line 9, in <module>
    load_entry_point('Holocron==0.1', 'console_scripts', 'holocron')()
  File "/home/propheticbird/Projects/holocron/holocron/main.py", line 124, in main
    commands[arguments.command].execute(holocron, arguments)
KeyError: None
````
Instead of this, we are now displaying help message.
