### PR TITLE
Use upstream mock library

### DIFF
--- a/tests/ext/commands/test_build.py
+++ b/tests/ext/commands/test_build.py
@@ -10,8 +10,8 @@
 """
 
 import argparse
-from unittest import mock
 
+import mock
 from dooku.conf import Conf
 
 from holocron.app import Holocron

--- a/tests/ext/commands/test_init.py
+++ b/tests/ext/commands/test_init.py
@@ -10,7 +10,8 @@
 """
 
 import os
-from unittest import mock
+
+import mock
 
 from holocron.app import Holocron
 from holocron.ext.commands import init

--- a/tests/ext/commands/test_serve.py
+++ b/tests/ext/commands/test_serve.py
@@ -10,8 +10,8 @@
 """
 
 import os
-from unittest import mock
 
+import mock
 from dooku.conf import Conf
 
 from holocron.app import Holocron
@@ -167,7 +167,7 @@ class TestChangeWatcher(HolocronTestCase):
 
     def test_process(self):
         self.watcher.process('a')
-        self.fake_builder.rebuild.assert_called_one_with()
+        self.fake_builder.rebuild.assert_called_once_with()
 
     def test_process_watch_for(self):
         self.watcher = serve._ChangeWatcher(self.fake_builder, watch_for=['a'])
@@ -176,7 +176,7 @@ class TestChangeWatcher(HolocronTestCase):
         self.assertEqual(self.fake_builder.rebuild.call_count, 0)
 
         self.watcher.process('a')
-        self.fake_builder.rebuild.assert_called_one_with()
+        self.fake_builder.rebuild.assert_called_once_with()
 
     def test_process_ignore(self):
         self.watcher = serve._ChangeWatcher(self.fake_builder, ignore=['a'])
@@ -185,7 +185,7 @@ class TestChangeWatcher(HolocronTestCase):
         self.assertEqual(self.fake_builder.rebuild.call_count, 0)
 
         self.watcher.process('x')
-        self.fake_builder.rebuild.assert_called_one_with()
+        self.fake_builder.rebuild.assert_called_once_with()
 
     def test_process_watch_for_and_ignore(self):
         self.watcher = serve._ChangeWatcher(
@@ -195,7 +195,7 @@ class TestChangeWatcher(HolocronTestCase):
         self.assertEqual(self.fake_builder.rebuild.call_count, 0)
 
         self.watcher.process('b')
-        self.fake_builder.rebuild.assert_called_one_with()
+        self.fake_builder.rebuild.assert_called_once_with()
 
     def test_process_skips_output(self):
         self.watcher.process(os.path.abspath('path/output/doc.txt'))
@@ -206,7 +206,7 @@ class TestChangeWatcher(HolocronTestCase):
             self.fake_builder, recreate_app=True)
         self.watcher.process('a')
 
-        self.fake_builder.recreate_app.assert_called_one_with()
+        self.fake_builder.recreate_app.assert_called_once_with()
 
 
 class TestBuilder(HolocronTestCase):

--- a/tests/ext/generators/test_feed.py
+++ b/tests/ext/generators/test_feed.py
@@ -9,11 +9,12 @@
     :license: 3-clause BSD, see LICENSE for details.
 """
 
-from unittest import mock
 from datetime import datetime
 from xml.dom import minidom
 
+import mock
 from dooku.conf import Conf
+
 from holocron.ext.generators import feed
 from holocron.content import Post, Page, Static
 from holocron.app import Holocron

--- a/tests/ext/generators/test_index.py
+++ b/tests/ext/generators/test_index.py
@@ -9,10 +9,11 @@
     :license: 3-clause BSD, see LICENSE for details.
 """
 
-from unittest import mock
 from datetime import datetime
 
+import mock
 from dooku.conf import Conf
+
 from holocron.ext.generators import index
 from holocron.content import Post, Page, Static
 from holocron.app import Holocron

--- a/tests/ext/generators/test_sitemap.py
+++ b/tests/ext/generators/test_sitemap.py
@@ -10,10 +10,11 @@
 """
 
 from datetime import datetime
-from unittest import mock
 from xml.dom import minidom
 
+import mock
 from dooku.conf import Conf
+
 from holocron.ext.generators import sitemap
 from holocron.content import Page, Post, Static
 

--- a/tests/ext/generators/test_tags.py
+++ b/tests/ext/generators/test_tags.py
@@ -10,10 +10,11 @@
 """
 
 import textwrap
-from unittest import mock
 from datetime import datetime
 
+import mock
 from dooku.conf import Conf
+
 from holocron.ext.generators.tags import Tags, Tag
 from holocron.content import Post, Page, Static
 from holocron.app import Holocron

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,8 @@
 import os
 import copy
 import textwrap
-from unittest import mock
+
+import mock
 
 import holocron
 from holocron.app import Holocron, create_app

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -11,9 +11,10 @@
 
 import os
 import datetime
-from unittest import mock
 
+import mock
 from dooku.conf import Conf
+
 from holocron import app, content
 from holocron.ext.converters import markdown
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,8 +10,8 @@
 """
 
 import logging
-from unittest import mock
 
+import mock
 from dooku.ext import ExtensionManager
 
 from holocron.app import Holocron

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@
     :license: 3-clause BSD, see LICENSE for details.
 """
 
-from unittest import mock
+import mock
 
 from holocron.utils import mkdir, normalize_url, iterfiles
 from tests import HolocronTestCase

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 [testenv]
 deps =
   pytest
+  mock
 commands =
   py.test {posargs:tests}
 


### PR DESCRIPTION
Upstream mock library has some improvements over standard one. For
instance, it forbids to call wrong (misspelled) assert_* methods of
mock.

Fixed #142