### PR TITLE
Don't turn off STDOUT/STDERR in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,8 +9,6 @@
     :license: 3-clause BSD, see LICENSE for details.
 """
 
-import sys
-import logging
 import unittest
 
 
@@ -18,8 +16,3 @@ class HolocronTestCase(unittest.TestCase):
     """
     Base class for all the tests that Holocron uses.
     """
-    #: disable holocron's logging output during tests
-    logging.disable(logging.CRITICAL)
-
-    #: disable holocron's message output during tests
-    sys.stdout = None


### PR DESCRIPTION
It makes no sense to turn off STDOUT/STDERR in tests, because py.test
does it automatically. So let's keep code clear and simple.