### PR TITLE
Make project tox (py2) compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: python
 
-python:
-  - "3.4"
-
 install:
   - pip install tox coveralls
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+from io import open
 from setuptools import setup, find_packages
 
 from holocron import __version__ as holocron_version


### PR DESCRIPTION
Previously due to py3 specific syntax we were unable to run tox if it's
installed in py2 env. Since tox manages Py envs for us, it doesn't
matter whether tox is installed in py2 or py3 envs.

So let's make things easier to use and do allow to run tests using tox
from py2 env.