### PR TITLE
Add Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+python: 3.5
 
 install:
   - pip install tox coveralls

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py33, py34, flake8, coverage, docs
+  py33, py34, py35, flake8, coverage, docs
 
 [testenv]
 deps =


### PR DESCRIPTION
Since Python 3.5 the 'os.walk' implementation has been changed, so it
was required to fix our 'iterfiles' tests to mock 'os.walk' directly,
not low level filesystem calls.

Signed-off-by: Igor Kalnitsky <igor@kalnitsky.org>