### PR TITLE
Fix Markdown title parser

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Here you can see the list of changes between each Holocron release.
 ==================
 
 - reStructuredText converter is added.
+- Fix Markdown title parser for multi-<h1> documents.
 
 
 0.1.1 (2015-08-22)

--- a/holocron/ext/converters/markdown.py
+++ b/holocron/ext/converters/markdown.py
@@ -55,7 +55,7 @@ class Markdown(abc.Converter):
     def __init__(self, app):
         self._conf = Conf(self._default_conf, app.conf.get('ext.markdown', {}))
         self._markdown = markdown.Markdown(extensions=self._conf['extensions'])
-        self._re_title = re.compile('<h1>(.*)</h1>(.*)', re.M | re.S)
+        self._re_title = re.compile('<h1>(.*?)</h1>(.*)', re.M | re.S)
 
         app.add_converter(self)
 

--- a/tests/ext/converters/test_markdown.py
+++ b/tests/ext/converters/test_markdown.py
@@ -70,6 +70,46 @@ class TestMarkdownConverter(HolocronTestCase):
             '<h2>some section 2</h2>\s*'
             '<p>yyy</p>$'))
 
+    def test_two_titles(self):
+        """
+        Only first <h1> should be considered as title, other <h1> should
+        be kept as is.
+        """
+        meta, html = self.conv.to_html(textwrap.dedent('''\
+            some title
+            ==========
+
+            other title
+            ===========
+
+            xxx
+        '''))
+
+        self.assertEqual(meta['title'], 'some title')
+        self.assertRegexpMatches(html, (
+            '^<h1>other title</h1>\s*'
+            '<p>xxx</p>$'))
+
+    def test_no_title_in_the_middle(self):
+        """
+        Only <h1> on the beginning should be considered as title, <h1> in
+        the middle of content should be kept as is.
+        """
+        meta, html = self.conv.to_html(textwrap.dedent('''\
+            xxx
+
+            some title
+            ==========
+
+            yyy
+        '''))
+
+        self.assertNotIn('title', meta)
+        self.assertRegexpMatches(html, (
+            '^<p>xxx</p>\s*'
+            '<h1>some title</h1>\s*'
+            '<p>yyy</p>$'))
+
     def test_post_without_title(self):
         """
         Converter has to work even if there's no title in the document.

--- a/tests/ext/converters/test_restructuredtext.py
+++ b/tests/ext/converters/test_restructuredtext.py
@@ -98,3 +98,23 @@ class TestReStructuredTextConverter(HolocronTestCase):
         _, html = self.conv.to_html('test ``code``\n')
 
         self.assertEqual(html, '<p>test <code>code</code></p>')
+
+    def test_no_title_in_the_middle(self):
+        """
+        Only <h1> on the beginning should be considered as title, <h1> in
+        the middle of content should be kept as is.
+        """
+        meta, html = self.conv.to_html(textwrap.dedent('''\
+            xxx
+
+            some title
+            ==========
+
+            yyy
+        '''))
+
+        self.assertNotIn('title', meta)
+        self.assertRegexpMatches(html, (
+            '^<p>xxx</p>\s*'
+            '<h2>some title</h2>\s*'
+            '<p>yyy</p>$'))


### PR DESCRIPTION
Use non-greedy regex for title parsing in Markdown converter. Previousy,
it worked bad for documents with several <h1> tags.

For instance, the following markdown content:

    some title a
    ============

    some title b
    ============

    xxx

has been parsed as:

    title:      some title a</h1><h1>some title b
    content:    xxx