### PR TITLE
WIP: Measure coverages in .travis.yml, not tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ language: python
 python: 3.5
 
 install:
-  - pip install tox coveralls
+  - pip install tox
 
 script:
   - tox
 
 after_success:
+  - pip install coveralls
+  - coverage run --source=holocron setup.py test
   - coveralls
 
 notifications:

--- a/tox.ini
+++ b/tox.ini
@@ -16,15 +16,6 @@ deps =
 commands =
   flake8 {posargs:holocron tests}
 
-[testenv:coverage]
-basepython = python3
-deps =
-  pytest-cov
-  {[testenv]deps}
-commands =
-  coverage erase
-  py.test tests --cov holocron
-
 [testenv:docs]
 basepython = python3
 deps =


### PR DESCRIPTION
DO NOT MERGE

It makes sense to measure and submit coverage in one place. Besides tox
was designed to be a test runner, so let it be a test runner.