### PR TITLE
Bump Pygments version and add missing test_require

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 develop-eggs/
 dist/
 eggs/
+.eggs/
 lib/
 lib64/
 parts/

--- a/setup.py
+++ b/setup.py
@@ -35,15 +35,16 @@ setup(
     zip_safe=False,
 
     install_requires=[
-        'Jinja2 >= 2.7',        # core
-        'PyYAML >= 3.11',       # core
-        'dooku >= 0.3.0',       # core
-        'Pygments >= 1.6',      # core since required for various converters
+        'Jinja2   >= 2.7',      # core
+        'PyYAML   >= 3.11',     # core
+        'dooku    >= 0.3.0',    # core
+        'Pygments >= 2.0',      # core since required for various converters
 
         'Markdown >= 2.4',      # deps of markdown converter
         'docutils >= 0.12',     # deps of restructuredtext converter
         'watchdog >= 0.8.0',    # deps of serve command
     ],
+    test_require=['mock >= 1.1.0'],
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Let's use Pygments 2.0, since major version bump may have some
difference in API. It would be better to test and require agains only
2.x branch.

Also, the test_require statement has been added.