### PR TITLE
Add abc.Extension interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,13 +5,14 @@
 Here you can see the list of changes between each Holocron release.
 
 
-0.2.0 (inprogress)
+0.2.0 (unreleased)
 ==================
 
-- reStructuredText converter is added.
-- Fix Markdown title parser for multi-<h1> documents.
-- Add Python 3.5 support.
-- Fix security issue when content author may steal private date through
+- Added reStructuredText converter.
+- Added ``holocron.ext.abc.Extension`` interface.
+- Added Python 3.5 support.
+- Fixed Markdown title parser for documents with multiple <h1> titles..
+- Fixed security issue when content author may steal private data through
   content's meta header.
 
 

--- a/holocron/ext/abc.py
+++ b/holocron/ext/abc.py
@@ -13,6 +13,26 @@
 import abc
 
 
+class Extension(object, metaclass=abc.ABCMeta):
+    """
+    Abstract base class for Holocron extensions.
+
+    Holocron uses entry points based approach for extensions discovering.
+    Thus, entry points that are exported to ``holocron.ext`` namespace
+    will be considered as extensions, and Holocron will call them and pass
+    its instance as argument. Further, it will be up to extension to decide
+    what to do (it can register a converter, generator, etc).
+
+    .. versionadded:: 0.2.0
+
+    :param app: an application instance
+    """
+
+    @abc.abstractmethod
+    def __init__(self, app):
+        """Initialize extension."""
+
+
 class Command(object, metaclass=abc.ABCMeta):
     """
     Abstract base class for 'Command' extensions.

--- a/holocron/ext/converters/markdown.py
+++ b/holocron/ext/converters/markdown.py
@@ -17,7 +17,7 @@ from dooku.conf import Conf
 from holocron.ext import abc
 
 
-class Markdown(abc.Converter):
+class Markdown(abc.Extension, abc.Converter):
     """
     A markdown converter.
 

--- a/holocron/ext/converters/restructuredtext.py
+++ b/holocron/ext/converters/restructuredtext.py
@@ -18,7 +18,7 @@ from dooku.conf import Conf
 from holocron.ext import abc
 
 
-class ReStructuredText(abc.Converter):
+class ReStructuredText(abc.Extension, abc.Converter):
     """
     A reStructuredText converter.
 

--- a/holocron/ext/generators/feed.py
+++ b/holocron/ext/generators/feed.py
@@ -21,7 +21,7 @@ from holocron.utils import normalize_url, mkdir
 from holocron.content import Post
 
 
-class Feed(abc.Generator):
+class Feed(abc.Extension, abc.Generator):
     """
     An Atom feed generator.
 
@@ -90,8 +90,6 @@ class Feed(abc.Generator):
     }
 
     def __init__(self, app):
-        super(Feed, self).__init__()
-
         self._appconf = app.conf
         self._conf = Conf(self._default_conf, app.conf.get('ext.feed', {}))
         self._url = normalize_url(app.conf['site.url']) + self._conf['save_as']

--- a/holocron/ext/generators/index.py
+++ b/holocron/ext/generators/index.py
@@ -17,7 +17,7 @@ from holocron.ext import abc
 from holocron.content import Post
 
 
-class Index(abc.Generator):
+class Index(abc.Extension, abc.Generator):
     """
     An index page generator.
 
@@ -49,11 +49,10 @@ class Index(abc.Generator):
     }
 
     def __init__(self, app):
-        super(Index, self).__init__()
-
         self._conf = Conf(self._default_conf, app.conf.get('ext.index', {}))
         self._encoding = app.conf['encoding.output']
         self._template = app.jinja_env.get_template(self._conf['template'])
+
         # An output filename. Why this? Because we want to see this page
         # by typing site url in a browser and http servers are usually
         # looking for this file if none was specified.

--- a/holocron/ext/generators/sitemap.py
+++ b/holocron/ext/generators/sitemap.py
@@ -18,7 +18,7 @@ from holocron.content import Page, Post
 from holocron.ext import abc
 
 
-class Sitemap(abc.Generator):
+class Sitemap(abc.Extension, abc.Generator):
     """
     A sitemap generator.
 
@@ -55,8 +55,6 @@ class Sitemap(abc.Generator):
           </urlset>'''))
 
     def __init__(self, app):
-        super(Sitemap, self).__init__()
-
         self._encoding = app.conf['encoding.output']
         self._save_as = os.path.join(app.conf['paths.output'], self._save_as)
 

--- a/holocron/ext/generators/tags.py
+++ b/holocron/ext/generators/tags.py
@@ -33,7 +33,7 @@ class Tag(object):
             output.format(tag=name).lstrip('/').rstrip('/'))
 
 
-class Tags(abc.Generator):
+class Tags(abc.Extension, abc.Generator):
     """
     A tags generator.
 
@@ -67,8 +67,6 @@ class Tags(abc.Generator):
     }
 
     def __init__(self, app):
-        super(Tags, self).__init__()
-
         self._conf = Conf(self._default_conf, app.conf.get('ext.tags', {}))
         self._encoding = app.conf['encoding.output']
         self._template = app.jinja_env.get_template(self._conf['template'])

--- a/holocron/main.py
+++ b/holocron/main.py
@@ -20,9 +20,6 @@ from holocron import __version__ as holocron_version
 from holocron.app import create_app
 
 
-logger = logging.getLogger(__name__)
-
-
 def configure_logger(level):
     """
     Configure a root logger to print records in pretty format.


### PR DESCRIPTION
Despite the fact Holocron doesn't care whether extension inherits base
classes (aka interfaces) until it ducks so, it's generally a good idea
to have interfaces anyway. Interfaces are useful in Python as a sort
of documentation, and they ensure you have implemented all needed
methods.