### PR TITLE
Use safe_load for reading content's headers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Here you can see the list of changes between each Holocron release.
 - reStructuredText converter is added.
 - Fix Markdown title parser for multi-<h1> documents.
 - Add Python 3.5 support.
+- Fix security issue when content author may steal private date through
+  content's meta header.
 
 
 0.1.1 (2015-08-22)

--- a/holocron/app.py
+++ b/holocron/app.py
@@ -41,7 +41,7 @@ def create_app(confpath=None):
                 # the conf may contain the {here} macro, so we have to
                 # replace it with actual value.
                 here = os.path.dirname(os.path.abspath(confpath))
-                conf = yaml.load(f.read().format(here=here))
+                conf = yaml.safe_load(f.read().format(here=here))
 
     except (FileNotFoundError, PermissionError) as exc:
         # it's ok that a user doesn't have a settings file or doesn't have

--- a/holocron/content.py
+++ b/holocron/content.py
@@ -166,7 +166,7 @@ class Page(Document):
             match = self._re_extract_header.match(content)
             if match:
                 headers, content = match.groups()
-                headers = yaml.load(headers)
+                headers = yaml.safe_load(headers)
 
             # get converter for building a given document
             converter = self._app._converters[os.path.splitext(self.source)[1]]


### PR DESCRIPTION
It's completely unnecessary and dangerous to use `yaml.load()` for
content's meta header. If there will be some service around Holocron,
and regular use will have permissions to create posts / pages, he would
be able to steal private data. In order to prevent this sort of attacks,
let's use `yaml.safe_load()` instead.