### PR TITLE
Fixed YAML header parser

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Here you can see the list of changes between each Holocron release.
 - Fixed Markdown title parser for documents with multiple <h1> titles..
 - Fixed security issue when content author may steal private data through
   content's meta header.
+- Fixed YAML header parser for documents with multiple ``---`` signs.
 
 
 0.1.1 (2015-08-22)

--- a/holocron/content.py
+++ b/holocron/content.py
@@ -132,7 +132,7 @@ class Page(Document):
     """
 
     #: A regex for splitting page header and page content.
-    _re_extract_header = re.compile('(---\s*\n.*\n)---\s*\n(.*)', re.M | re.S)
+    _re_extract_header = re.compile('(---\s*\n.*?\n)---\s*\n(.*)', re.M | re.S)
 
     #: A default template for page documents.
     template = 'page.html'


### PR DESCRIPTION
We have to use non-greedy regex for extracting YAML header, since
otherwise parser is broken for documents with multiple `---` signs.