### PR TITLE
Make ext tests independent from each other

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,6 +10,18 @@
 """
 
 import unittest
+from holocron.ext import abc
+
+
+class FakeConverter(abc.Converter):
+    """
+    Fake converter class that converts *.fake files into HTML. It's used by
+    some tests where we need to check rendered HTML code.
+    """
+    extensions = ['.fake']
+
+    def to_html(self, text):
+        return {}, 'html_text'
 
 
 class HolocronTestCase(unittest.TestCase):

--- a/tests/ext/converters/test_markdown.py
+++ b/tests/ext/converters/test_markdown.py
@@ -25,6 +25,7 @@ class TestMarkdownConverter(HolocronTestCase):
     def setUp(self):
         self.conv = markdown.Markdown(Holocron(conf={
             'ext': {
+                'enabled': [],
                 'markdown': {
                     'extensions': [],
                 },
@@ -127,6 +128,7 @@ class TestMarkdownConverter(HolocronTestCase):
         """
         self.conv = markdown.Markdown(Holocron(conf={
             'ext': {
+                'enabled': [],
                 'markdown': {
                     'extensions': ['codehilite'],
                 },
@@ -148,6 +150,7 @@ class TestMarkdownConverter(HolocronTestCase):
         """
         self.conv = markdown.Markdown(Holocron(conf={
             'ext': {
+                'enabled': [],
                 'markdown': {
                     'extensions': ['codehilite', 'extra'],
                 },
@@ -168,6 +171,7 @@ class TestMarkdownConverter(HolocronTestCase):
         """
         self.conv = markdown.Markdown(Holocron(conf={
             'ext': {
+                'enabled': [],
                 'markdown': {
                     'extensions': ['extra'],
                 },

--- a/tests/ext/converters/test_restructuredtext.py
+++ b/tests/ext/converters/test_restructuredtext.py
@@ -23,7 +23,11 @@ class TestReStructuredTextConverter(HolocronTestCase):
     """
 
     def setUp(self):
-        self.conv = restructuredtext.ReStructuredText(Holocron())
+        self.conv = restructuredtext.ReStructuredText(Holocron(conf={
+            'ext': {
+                'enabled': [],
+            },
+        }))
 
     def test_simple_post(self):
         """

--- a/tests/ext/generators/test_feed.py
+++ b/tests/ext/generators/test_feed.py
@@ -13,13 +13,12 @@ from datetime import datetime
 from xml.dom import minidom
 
 import mock
-from dooku.conf import Conf
 
-from holocron.ext.generators import feed
-from holocron.content import Post, Page, Static
 from holocron.app import Holocron
+from holocron.content import Post, Page, Static
+from holocron.ext.generators import feed
 
-from tests import HolocronTestCase
+from tests import HolocronTestCase, FakeConverter
 
 
 class TestFeedGenerator(HolocronTestCase):
@@ -28,7 +27,7 @@ class TestFeedGenerator(HolocronTestCase):
     """
 
     def setUp(self):
-        self.app = Holocron(conf=Conf({
+        self.app = Holocron(conf={
             'site': {
                 'title': 'MyTestSite',
                 'author': 'Tester',
@@ -44,14 +43,13 @@ class TestFeedGenerator(HolocronTestCase):
             },
 
             'ext': {
-                'enabled': ['feed', 'markdown'],
-
+                'enabled': [],
                 'feed': {
                     'save_as': 'myfeed.xml',
                     'posts_number': 3,
                 },
             },
-        }))
+        })
         self.feed = feed.Feed(self.app)
 
         self.date_early = datetime(2012, 2, 2)
@@ -287,9 +285,13 @@ class TestFeedGenerator(HolocronTestCase):
         """
         Test that html pages have the link to feed.
         """
+        # since we're interested in rendered page, let's register
+        # a fake converter for that purpose
+        self.app.add_converter(FakeConverter())
+
         open_fn = 'holocron.content.open'
         with mock.patch(open_fn, mock.mock_open(read_data=''), create=True):
-            page = Page('filename.mdown', self.app)
+            page = Page('filename.fake', self.app)
 
         with mock.patch(open_fn, mock.mock_open(), create=True) as mopen:
             page.build()

--- a/tests/ext/generators/test_index.py
+++ b/tests/ext/generators/test_index.py
@@ -12,7 +12,6 @@
 from datetime import datetime
 
 import mock
-from dooku.conf import Conf
 
 from holocron.ext.generators import index
 from holocron.content import Post, Page, Static
@@ -36,8 +35,7 @@ class TestIndexGenerator(HolocronTestCase):
         Creates generator object and number of posts which will be further used
         in test sets.
         """
-
-        self.index = index.Index(Holocron(conf=Conf({
+        self.app = Holocron(conf={
             'sitename': 'MyTestSite',
             'siteurl': 'www.mytest.com',
             'author': 'Tester',
@@ -49,7 +47,12 @@ class TestIndexGenerator(HolocronTestCase):
             'paths': {
                 'output': 'path/to/output',
             },
-        })))
+
+            'ext': {
+                'enabled': [],
+            },
+        })
+        self.index = index.Index(self.app)
 
         self.open_fn = 'holocron.ext.generators.index.open'
 

--- a/tests/ext/generators/test_sitemap.py
+++ b/tests/ext/generators/test_sitemap.py
@@ -13,8 +13,8 @@ from datetime import datetime
 from xml.dom import minidom
 
 import mock
-from dooku.conf import Conf
 
+from holocron.app import Holocron
 from holocron.ext.generators import sitemap
 from holocron.content import Page, Post, Static
 
@@ -27,14 +27,20 @@ class TestSitemapGenerator(HolocronTestCase):
         """
         Prepares a sitemap instance with a fake config.
         """
-        self.sitemap = sitemap.Sitemap(mock.Mock(conf=Conf({
+        self.app = Holocron(conf={
             'encoding': {
                 'output': 'my-enc',
             },
+
             'paths': {
                 'output': 'path/to/output',
-            }
-        })))
+            },
+
+            'ext': {
+                'enabled': [],
+            },
+        })
+        self.sitemap = sitemap.Sitemap(self.app)
 
         self.open_fn = 'holocron.ext.generators.sitemap.open'
 

--- a/tests/ext/generators/test_tags.py
+++ b/tests/ext/generators/test_tags.py
@@ -13,13 +13,12 @@ import textwrap
 from datetime import datetime
 
 import mock
-from dooku.conf import Conf
 
-from holocron.ext.generators.tags import Tags, Tag
-from holocron.content import Post, Page, Static
 from holocron.app import Holocron
+from holocron.content import Post, Page, Static
+from holocron.ext.generators.tags import Tags, Tag
 
-from tests import HolocronTestCase
+from tests import HolocronTestCase, FakeConverter
 
 
 class TestTagObjects(HolocronTestCase):
@@ -61,7 +60,7 @@ class TestTagsGenerator(HolocronTestCase):
     h_year = '<h2>{0}</h2>'.format
 
     def setUp(self):
-        self.app = Holocron(conf=Conf({
+        self.app = Holocron(conf={
             'sitename': 'MyTestSite',
             'siteurl': 'www.mytest.com',
             'author': 'Tester',
@@ -75,11 +74,12 @@ class TestTagsGenerator(HolocronTestCase):
             },
 
             'ext': {
+                'enabled': [],
                 'tags': {
                     'output': 'mypath/tags/{tag}',
                 },
             },
-        }))
+        })
         self.tags = Tags(self.app)
 
         self.date_early = datetime(2012, 2, 2)
@@ -215,6 +215,10 @@ class TestTagsGenerator(HolocronTestCase):
         """
         Test that tags are actually get to the output.
         """
+        # since we're interested in rendered page, let's register
+        # a fake converter for that purpose
+        self.app.add_converter(FakeConverter())
+
         data = textwrap.dedent('''\
             ---
             tags: [tag1, tag2]
@@ -224,7 +228,7 @@ class TestTagsGenerator(HolocronTestCase):
 
         open_fn = 'holocron.content.open'
         with mock.patch(open_fn, mock.mock_open(read_data=data), create=True):
-            post = Post('2015/05/23/filename.mdown', self.app)
+            post = Post('2015/05/23/filename.fake', self.app)
 
         self._get_content([post])
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -190,23 +190,23 @@ class TestHolocronDefaults(HolocronTestCase):
         """
         converters_cls = {type(conv) for conv in self.app._converters.values()}
 
-        self.assertEqual(converters_cls, set([
+        self.assertCountEqual(converters_cls, [
             converters.markdown.Markdown,
             converters.restructuredtext.ReStructuredText,
-        ]))
+        ])
 
     def test_registered_generators(self):
         """
         Tests that default generators are registered.
         """
-        generators_cls = {type(gen) for gen in self.app._generators}
+        generators_cls = [type(gen) for gen in self.app._generators]
 
-        self.assertEqual(generators_cls, set([
+        self.assertCountEqual(generators_cls, [
             generators.feed.Feed,
             generators.index.Index,
             generators.sitemap.Sitemap,
             generators.tags.Tags,
-        ]))
+        ])
 
 
 class TestCreateApp(HolocronTestCase):

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -17,10 +17,10 @@ import mock
 import yaml
 from dooku.conf import Conf
 
-from holocron import app, content
-from holocron.ext.converters import markdown
+from holocron.app import Holocron
+from holocron import content
 
-from tests import HolocronTestCase
+from tests import HolocronTestCase, FakeConverter
 
 
 class DocumentTestCase(HolocronTestCase):
@@ -32,7 +32,7 @@ class DocumentTestCase(HolocronTestCase):
     _getctime = 662739000   # UTC: 1991/01/01 2:10pm
     _getmtime = 1420121400  # UTC: 2015/01/01 2:10pm
 
-    _fake_conf = Conf(app.Holocron.default_conf, {
+    _conf = Conf({
         'site': {
             'url': 'http://example.com',
         },
@@ -57,18 +57,17 @@ class DocumentTestCase(HolocronTestCase):
         Prepares a document instance with a fake config.
         """
         filename = os.path.join(
-            self._fake_conf['paths.content'], self.document_filename)
-        self._fake_app = mock.Mock(conf=self._fake_conf)
+            self._conf['paths.content'], self.document_filename)
 
-        self.doc = self.document_class(filename, mock.Mock(
-            _converters={
-                '.mdown': markdown.Markdown(self._fake_app), },
-            conf=self._fake_conf))
+        self.app = Holocron(self._conf)
+        self.app.add_converter(FakeConverter())
+
+        self.doc = self.document_class(filename, self.app)
 
 
 class TestDocument(DocumentTestCase):
     """
-    Tests for an abstract document base class.
+    Tests an abstract document base class.
     """
 
     class DocumentImpl(content.Document):
@@ -146,7 +145,7 @@ class TestDocument(DocumentTestCase):
 
 class TestPage(DocumentTestCase):
     """
-    Tests for a Page document.
+    Tests Page document.
     """
 
     _open_fn = 'holocron.content.open'
@@ -210,7 +209,7 @@ class TestPage(DocumentTestCase):
         with mock.patch(self._open_fn, mopen, create=True):
             super(TestPage, self).setUp()
 
-        self.assertEqual(self.doc.author, self._fake_conf['site.author'])
+        self.assertEqual(self.doc.author, self.app.conf['site.author'])
         self.assertEqual(self.doc.template, self.document_class.template)
         self.assertEqual(self.doc.title, self.document_class.title)
 
@@ -241,9 +240,12 @@ class TestPage(DocumentTestCase):
         """
         The page instance has to be rendered in the right place.
         """
+        self.app.jinja_env = mock.Mock()
         mopen = mock.mock_open(read_data=self._document_no_meta_raw)
         with mock.patch(self._open_fn, mopen, create=True):
             self.doc.build()
+
+        self.app.jinja_env.get_template.assert_called_once_with('mypage.html')
 
         self.assertEqual(
             mopen.call_args[0][0], './_output/about/cv/index.html')
@@ -253,7 +255,7 @@ class TestPage(DocumentTestCase):
 
 class TestPost(TestPage):
     """
-    Tests for a Post document.
+    Tests Post document.
     """
 
     document_class = content.Post
@@ -272,9 +274,12 @@ class TestPost(TestPage):
         """
         The post instance has to be rendered in the right place.
         """
+        self.app.jinja_env = mock.Mock()
         mopen = mock.mock_open(read_data=self._document_no_meta_raw)
         with mock.patch(self._open_fn, mopen, create=True):
             self.doc.build()
+
+        self.app.jinja_env.get_template.assert_called_once_with('mypage.html')
 
         self.assertEqual(
             mopen.call_args[0][0], './_output/2014/10/8/testpost/index.html')
@@ -293,7 +298,7 @@ class TestPost(TestPage):
 
 class TestStatic(DocumentTestCase):
     """
-    Tests for a Static document.
+    Tests Static document.
     """
 
     document_class = content.Static
@@ -309,7 +314,7 @@ class TestStatic(DocumentTestCase):
 
 class TestDocumentFactory(HolocronTestCase):
     """
-    Tests for the create_document functions.
+    Tests the create_document function.
     """
 
     @mock.patch('holocron.content.Page._parse_document', return_value={})
@@ -317,22 +322,19 @@ class TestDocumentFactory(HolocronTestCase):
     @mock.patch('holocron.content.os.path.getctime')
     @mock.patch('holocron.content.os.getcwd', return_value='cwd')
     def _create_document(self, filename, getcwd, getctime, getmtime, _):
-        fake_app = mock.Mock(
-            _converters={
-                '.mdown': mock.Mock(),
-            },
-            conf=Conf(app.Holocron.default_conf, {
-                'paths': {
-                    'content': './content',
-                }
-            }))
-        return content.create_document(filename, fake_app)
+        app = Holocron({
+            'paths': {
+                'content': './content',
+            }
+        })
+        app.add_converter(FakeConverter())
+        return content.create_document(filename, app)
 
     def test_create_post(self):
         """
         Tests that create_document creates a Post instance in right cases.
         """
-        document = self._create_document('content/2015/01/04/test.mdown')
+        document = self._create_document('content/2015/01/04/test.fake')
         self.assertIsInstance(document, content.Post)
 
     def test_create_page(self):
@@ -340,9 +342,10 @@ class TestDocumentFactory(HolocronTestCase):
         Tests that create_document creates a Page instance in right cases.
         """
         corner_cases = (
-            'content/test/test.mdown',
-            'content/2014/test.mdown',
-            'content/2014/01/test.mdown', )
+            'content/test/test.fake',
+            'content/2014/test.fake',
+            'content/2014/01/test.fake',
+        )
 
         for case in corner_cases:
             document = self._create_document(case)
@@ -356,7 +359,8 @@ class TestDocumentFactory(HolocronTestCase):
             'content/2015/01/04/test.png',
             'content/2015/01/test.png',
             'content/2015/test.png',
-            'content/test/test.png', )
+            'content/test/test.png',
+        )
 
         for case in corner_cases:
             document = self._create_document(case)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,16 +20,20 @@ class TestMkdir(HolocronTestCase):
     @mock.patch('holocron.utils.os.path.exists', return_value=False)
     @mock.patch('holocron.utils.os.makedirs')
     def test_makedirs_is_called(self, makedirs, _):
-
+        """
+        Tests that os.makedirs has been called if path not exists.
+        """
         mkdir('path/to/dir')
         makedirs.assert_called_with('path/to/dir')
 
     @mock.patch('holocron.utils.os.path.exists', return_value=True)
     @mock.patch('holocron.utils.os.makedirs')
     def test_makedirs_is_not_called(self, makedirs, _):
-
+        """
+        Tests that os.makedirs hasn't been called if path exist.
+        """
         mkdir('path/to/dir')
-        self.assertFalse(makedirs.called)
+        makedirs.assert_not_called()
 
 
 class TestNormalizeUrl(HolocronTestCase):


### PR DESCRIPTION
Some of our tests have been depended on implicitly enabled extensions.
For instance, Feed extension has depended on Markdown while Markdown
wasn't enabled explicitly. That's not good since even slight change in
our defaults will break this test. It's better to be clear here, and
don't rely on other extensions at all.

This commit removes such dependencies, and, for example, Feed extension
uses fake converter from now on.