### PR TITLE
Report combined coverage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Links
 .. |license| image:: https://img.shields.io/pypi/l/holocron.svg
    :target: https://pypi.python.org/pypi/holocron
 
-.. |travis-ci| image:: https://img.shields.io/travis/ikalnitsky/holocron/master.svg
+.. |travis-ci| image:: https://img.shields.io/travis/ikalnitsky/holocron.svg
    :target: https://travis-ci.org/ikalnitsky/holocron
 
 .. |coveralls| image:: https://img.shields.io/coveralls/ikalnitsky/holocron.svg

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist =
-  py33, py34, py35, flake8, coverage, docs
+  py33, py34, py35, flake8, docs
 
 [testenv]
 deps =
   pytest
+  pytest-cov
   mock
 commands =
-  py.test {posargs:tests}
+  py.test --cov holocron --cov-append {posargs:tests}
 
 [testenv:flake8]
 basepython = python3
@@ -15,15 +16,6 @@ deps =
   flake8
 commands =
   flake8 {posargs:holocron tests}
-
-[testenv:coverage]
-basepython = python3
-deps =
-  pytest-cov
-  {[testenv]deps}
-commands =
-  coverage erase
-  py.test tests --cov holocron
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
It makes more sense to measure combined coverage (combined across
different interpreters), because the code itself may have corner cases
for particular python versions (e.g. if Python 2.7 then do something).