### PR TITLE
Run flake8 and setup.py checks as part of testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,17 @@
 [tox]
 envlist =
-  py33, py34, py35, flake8, docs
+  py33, py34, py35, docs
 
 [testenv]
 deps =
   pytest
   pytest-cov
   mock
-commands =
-  py.test --cov holocron --cov-append {posargs:tests}
-
-[testenv:flake8]
-basepython = python3
-skip_install = true
-deps =
   flake8
 commands =
-  flake8 {posargs:holocron tests}
+  python setup.py check --strict
+  flake8 holocron/ tests/
+  py.test --cov holocron/ --cov-append tests/
 
 [testenv:docs]
 skip_install = true


### PR DESCRIPTION
Both `flake8` and `setup.py check` may show different results on different
interpreters, so it makes sense to run them for each interpreter before
unit tests.