### PR TITLE
Use pip3 in installation examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Feel the Force? Then use Holocron!
 
 .. code:: bash
 
-    $ [sudo] pip install holocron
+    $ [sudo] pip3 install holocron
 
 
 Features

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Feel the Force? Then use Holocron!
 
 .. code:: bash
 
-    $ [sudo] pip install holocron
+    $ [sudo] pip3 install holocron
 
 
 Features

--- a/holocron/example/2014/04/20/holocron.mdown
+++ b/holocron/example/2014/04/20/holocron.mdown
@@ -72,7 +72,7 @@ Holocron is written on Python and destributed as a Python package on PyPI.
 So you can easily install it via `pip` tool:
 
 ```bash
-$ [sudo] pip install holocron
+$ [sudo] pip3 install holocron
 ```
 
 Basic Usage
@@ -101,4 +101,4 @@ Links
 
 [repository]: https://github.com/ikalnitsky/holocron
 [issue tracker]: https://github.com/ikalnitsky/holocron/issues
-[documentation]: https://readthedocs.org
+[documentation]: https://holocron.readthedocs.org


### PR DESCRIPTION
Since Holocron works only under Python 3.3+, we should show proper pip
executable in installation examples.