### PR TITLE
Fix ordering of posts on index and tags pages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Here you can see the list of changes between each Holocron release.
 
 0.3.0 (unreleased)
 ==================
+- Fixed posts ordering on index and tags pages.
 
 
 0.2.0 (2015-12-16)

--- a/holocron/theme/templates/document-list.html
+++ b/holocron/theme/templates/document-list.html
@@ -18,7 +18,7 @@
 {% for group in posts|groupby('published.year')|sort(attribute='grouper', reverse=True) %}
   <span class="year">{{ group.grouper }}</span>
 
-  {% for post in group.list %}
+  {% for post in group.list|sort(attribute='published', reverse=True) %}
   <div class="index-entry">
     <time datetime="{{ post.published.isoformat() }}">
       {{ post.published.strftime('%b %d, %Y') }}


### PR DESCRIPTION
Holocron's default theme ordered posts by year, but didn't take into account
other date attributes. This commit fixes the issue.

Closed #169