### PR TITLE
Always show deprecation warnings

### DIFF
--- a/holocron/example/_config.yml
+++ b/holocron/example/_config.yml
@@ -64,8 +64,8 @@ ext:
    # generates html pages extracting some meta information (author name, tags)
    markdown:
       extensions:
-         - codehilite      # adds code/syntax highlighting
-         - extra           # enables tables, footnotes, etc
+         - markdown.extensions.codehilite  # adds code/syntax highlighting
+         - markdown.extensions.extra       # enables tables, footnotes, etc
 
    # reStructuredText is a converter that parses reStructuredText sources
    # and generated html pages extracting some meta information. Currently

--- a/holocron/ext/markdown.py
+++ b/holocron/ext/markdown.py
@@ -47,8 +47,8 @@ class Markdown(abc.Extension, abc.Converter):
 
     _default_conf = {
         'extensions': [
-            'codehilite',   # use pygments to highlight code-blocks
-            'extra',        # enable extended features like tables
+            'markdown.extensions.codehilite',  # highlight code blocks
+            'markdown.extensions.extra',       # extra features like tables
         ],
     }
 

--- a/holocron/main.py
+++ b/holocron/main.py
@@ -13,6 +13,7 @@
 import sys
 import logging
 import argparse
+import warnings
 
 from dooku.ext import ExtensionManager
 
@@ -119,6 +120,10 @@ def main(args=sys.argv[1:]):
     # initial logger configuration - use custom format for records
     # and print records with WARNING level and higher.
     configure_logger(arguments.verbosity or logging.WARNING)
+
+    # show deprecation warnings in order to be prepared for backward
+    # incompatible changes
+    warnings.filterwarnings('always', category=DeprecationWarning)
 
     # create app instance
     holocron = create_app(arguments.conf)

--- a/tests/ext/test_markdown.py
+++ b/tests/ext/test_markdown.py
@@ -130,7 +130,7 @@ class TestMarkdownConverter(HolocronTestCase):
             'ext': {
                 'enabled': [],
                 'markdown': {
-                    'extensions': ['codehilite'],
+                    'extensions': ['markdown.extensions.codehilite'],
                 },
             },
         }))
@@ -152,7 +152,10 @@ class TestMarkdownConverter(HolocronTestCase):
             'ext': {
                 'enabled': [],
                 'markdown': {
-                    'extensions': ['codehilite', 'extra'],
+                    'extensions': [
+                        'markdown.extensions.codehilite',
+                        'markdown.extensions.extra',
+                    ],
                 },
             },
         }))
@@ -173,7 +176,7 @@ class TestMarkdownConverter(HolocronTestCase):
             'ext': {
                 'enabled': [],
                 'markdown': {
-                    'extensions': ['extra'],
+                    'extensions': ['markdown.extensions.extra'],
                 },
             },
         }))


### PR DESCRIPTION
It's a good idea to always show deprecation warnings to warn users that
soon something will be broken and it's time to move toward new solution.

Besided it's good to see deprecation warnings for devs either, since some
libraries might deprecate some API either. For instance we used legacy
Markdown extensions API, this commit fixes it.