### PR TITLE
Implement API for theme extensions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,7 +7,15 @@ Here you can see the list of changes between each Holocron release.
 
 0.3.0 (unreleased)
 ==================
+
+- Added API for registering external themes. That means from now on themes
+  could be distributed as Holocron extensions via Python packaged.
+- Added User Theme extension that allows to setup external theme.
 - Fixed posts ordering on index and tags pages.
+- **DEPRECATED**: ``paths.theme`` option will be removed in favor of
+  ``ext.user-theme.path``
+- **DEPRECATED**: user theme won't be enabled by default, so please enable
+  it explicitly
 
 
 0.2.0 (2015-12-16)

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -222,3 +222,35 @@ where
 
 * ``template`` -- a template to be used to render tags index pages
 * ``output`` -- an output directory for tags index page
+
+
+User Theme
+==========
+
+.. list-table::
+   :stub-columns: 1
+   :widths: 1 100
+
+   * - Integrated
+     - yes
+
+   * - Description
+     - Allows to setup external theme for content rendering.
+
+When enabled, the ``_theme`` folder in current working directory will be
+consumed as user theme. The path could be changed using the following
+option:
+
+.. code:: yaml
+
+    ext:
+      user-theme:
+        path: {here}/_themes/my-awesome-theme
+
+where
+
+* ``{here}`` -- a macros that will be replaced by the path to directory with
+  configuration file (i.e. ``_config.yml``)
+
+.. note:: User Theme extension supersedes the core functionality, as well
+          as ``paths.theme`` setting.

--- a/holocron/ext/__init__.py
+++ b/holocron/ext/__init__.py
@@ -18,6 +18,8 @@ from .feed import Feed
 from .sitemap import Sitemap
 from .tags import Tags
 
+from .user_theme import UserTheme
+
 
 __all__ = [
     'Markdown',
@@ -27,4 +29,6 @@ __all__ = [
     'Feed',
     'Sitemap',
     'Tags',
+
+    'UserTheme',
 ]

--- a/holocron/ext/commands/serve.py
+++ b/holocron/ext/commands/serve.py
@@ -18,7 +18,6 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
-import holocron
 from holocron import app
 from holocron.ext import abc
 
@@ -179,16 +178,15 @@ class Serve(abc.Command):
             builder.shutdown()
 
     def _watch(self, app, arguments, builder):
-        # By default we're watching for events in both content and default
-        # theme directories.
+        # By default we're watching for events in content directory.
         watch_paths = [
             app.conf['paths.content'],
-            os.path.join(os.path.dirname(holocron.__file__), 'theme'),
         ]
 
-        # If user has his own theme - watch it too.
-        if os.path.exists(app.conf['paths.theme']):
-            watch_paths.append(app.conf['paths.theme'])
+        # But it'd be nice to watch themes directories either.
+        for theme in app._themes:
+            if os.path.exists(theme):
+                watch_paths.append(theme)
 
         observer = Observer()
         for path in watch_paths:

--- a/holocron/ext/user_theme.py
+++ b/holocron/ext/user_theme.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+"""
+    holocron.ext.user_theme
+    ~~~~~~~~~~~~~~~~~~~~~~~
+
+    This module implements an extension that allows to consume some
+    external theme and use it to render site content.
+
+    :copyright: (c) 2015 by the Holocron Team, see AUTHORS for details.
+    :license: 3-clause BSD, see LICENSE for details.
+"""
+
+from dooku.conf import Conf
+
+from holocron.ext import abc
+
+
+class UserTheme(abc.Extension):
+    """
+    Setup external theme for content rendering.
+
+    The extenstion supports only one option - ``path``::
+
+        ext:
+           user-theme:
+              path: 'path/to/external/theme'
+
+    .. versionadded:: 0.3.0
+
+    :param app: an application instance for which we're creating extension
+    """
+
+    _default_conf = {
+        'path': '_theme',
+    }
+
+    def __init__(self, app):
+        conf = Conf(self._default_conf, app.conf.get('ext.user-theme', {}))
+        app.add_theme(conf['path'])

--- a/holocron/main.py
+++ b/holocron/main.py
@@ -50,6 +50,9 @@ def configure_logger(level):
     logger.addHandler(stream_handler)
     logger.setLevel(level)
 
+    # capture warnings issued by 'warnings' module
+    logging.captureWarnings(True)
+
 
 def parse_command_line(args, commands):
     """

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ setup(
             'feed = holocron.ext:Feed',
             'sitemap = holocron.ext:Sitemap',
             'tags = holocron.ext:Tags',
+
+            'user-theme = holocron.ext:UserTheme',
         ],
         'holocron.ext.commands': [
             'init = holocron.ext.commands.init:Init',


### PR DESCRIPTION
The patch introduces API for registering new themes, that will be later
used for content rendering. So from now on it's allowed to create
third-party extensions which provide external themes.

As an example the ability to specify user theme is moved to extension.
It will be disabled by default in 0.4.0.