### PR TITLE
Do not scroll when ribbon is enabled

### DIFF
--- a/holocron/theme/static/style.css
+++ b/holocron/theme/static/style.css
@@ -15,16 +15,20 @@
     general
    -------------------------------------------------------------------- */
 
+html {
+  overflow-x: hidden;
+}
+
 body {
   border-top: 5px solid #2f5a8b;
   background-color: #fefefe;
   color: #3f3f3f;
   font: 18px/28px 'PT Serif', Georgia, serif;
+  position: relative;
   overflow-x: hidden;
 
   /* prevent font scaling in landscape for iPhone */
   -webkit-text-size-adjust: 100%;
-  text-size-adjust: 100%;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/holocron/theme/templates/base.html
+++ b/holocron/theme/templates/base.html
@@ -53,10 +53,7 @@
   </div> <!-- /.footer-wrapper -->
 
   {% if theme.ribbon %}
-  <a href="{{ theme.ribbon.link }}" class="ribbon">
-    {{ theme.ribbon.text }}
-  </a>
-  <!-- /.ribbon -->
+  <a href="{{ theme.ribbon.link }}" class="ribbon">{{ theme.ribbon.text }}</a>
   {% endif %}
 
 {% include 'counters.html' %}


### PR DESCRIPTION
There's Safari (probably webkit) bug with 'overflow-x: hidden' CSS rule.
The thing is that when it's enabled for body element, the scrollbar is
invisibe, but scrolling is working. This patch introduces workaround
for the issue.