### PR TITLE
Calesce together commit authors using .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Andrii Gamaiunov <andrii.gamaiunov@gmail.com> <agdrew4@gmail.com>
+Igor Kalnitsky <igor@kalnitsky.org>
+Olha Kurkaiedova <olya.kurkaedova@gmail.com>


### PR DESCRIPTION
The .mailmap feature is used to coalesce together commits by the same
person in the shortlog, where their name and/or email address was
spelled differently. So far '$ git shortlog -se' shows the following
output:

```
     2  Andrew <agdrew4@gmail.com>
    90  Andrii <agdrew4@gmail.com>
    26  Andrii Gamaiunov <agdrew4@gmail.com>
     2  Andrii Gamaiunov <andrii.gamaiunov@gmail.com>
   143  Igor Kalnitsky <igor@kalnitsky.org>
     1  PropheticBird <agdrew4@gmail.com>
     1  the-raven <olya.kurkaedova@gmail.com>
```

while this commit corrects it to be the following one:

```
   121  Andrii Gamaiunov <andrii.gamaiunov@gmail.com>
   144  Igor Kalnitsky <igor@kalnitsky.org>
     1  Olha Kurkaiedova <olya.kurkaedova@gmail.com>
```