### PR TITLE
Use Travis CI to release Holocron on PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,25 @@ language: python
 python: 3.5
 
 install:
-  - pip install tox coveralls
+   - pip install tox coveralls
 
 script:
-  - tox
+   - tox
 
 after_success:
-  - coveralls
+   - coveralls
+
+deploy:
+   - provider: pypi
+     user: ikalnitsky
+     password:
+        secure:
+           "XqusR3oOQFAKx/aGVwuIABxcS6vU1xcF/U9taCXRDwhQU3UeJVMabDhWpiHh+\
+            wmE785CZBCPVdq9bqJs1p75IOihV2L3gF8LNxY9LFeMKH6AU2bZHNfpF6CuYE\
+            j7a3KqmmGk0jMykAdOLqDlQHecBLEOfU7+YVdH1i1glpDLKhE="
+     on:
+        tags: true
+        distributions: sdist
 
 notifications:
-  email: false
+   email: false


### PR DESCRIPTION
It's very convenient to automate release uploading to PyPI when each tag
is pushed to GitHub repo.