### PR TITLE
theme: use grey underline for links in footer

### DIFF
--- a/holocron/theme/static/style.css
+++ b/holocron/theme/static/style.css
@@ -112,6 +112,11 @@ footer.footer {
   color: #777777;
 }
 
+footer.footer a {
+  color: #606060;
+  text-decoration: underline;
+}
+
 footer.footer p {
   margin: 0.5em 0;
 }


### PR DESCRIPTION
So far we use a global style for links on footer (blue), but it didn't
work well. Footer is a special case of site, it should not attract so
much attention. So it much better to use grey and underline style for
them.